### PR TITLE
feat: add product search filter

### DIFF
--- a/backend/server/rutas/producserv.js
+++ b/backend/server/rutas/producserv.js
@@ -10,10 +10,19 @@ const producPopulate = ['rubro', 'marca', 'unidaddemedida'];
 
 /** LISTAR (por defecto, sólo activos) */
 router.get('/producservs', asyncHandler(async (req, res) => {
-  const { desde = 0, limite = 500, incluirInactivos } = req.query;
-  //const query = incluirInactivos === 'true' ? {} : { activo: true };
+  const { desde = 0, limite = 500, search } = req.query;
 
-  const producservs = await Producserv.find()
+  // Filtro de búsqueda por código o descripción (case-insensitive)
+  const q = search
+    ? {
+        $or: [
+          { codprod: { $regex: search, $options: 'i' } },
+          { descripcion: { $regex: search, $options: 'i' } },
+        ],
+      }
+    : {};
+
+  const producservs = await Producserv.find(q)
     .skip(toNumber(desde, 0))
     .limit(toNumber(limite, 500))
     .sort('descripcion')
@@ -21,7 +30,7 @@ router.get('/producservs', asyncHandler(async (req, res) => {
     .lean()
     .exec();
 
-  const cantidad = await Producserv.countDocuments();
+  const cantidad = await Producserv.countDocuments(q);
   res.json({ ok: true, producservs, cantidad });
 }));
 

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -1,5 +1,9 @@
 import React, {
-  useState, useEffect, forwardRef, useImperativeHandle
+  useState,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+  useCallback,
 } from 'react';
 import {
   DataGrid, GridActionsCellItem
@@ -22,7 +26,7 @@ function CustomFooter({ totalCount = 0 }) {
   );
 }
 
-const ProductTable = forwardRef(function ProductTable({ onEdit }, ref) {
+const ProductTable = forwardRef(function ProductTable({ onEdit, search = '' }, ref) {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -30,12 +34,12 @@ const ProductTable = forwardRef(function ProductTable({ onEdit }, ref) {
   const [page, setPage] = useState(0);         // 0-based
   const [rowCount, setRowCount] = useState(0); // total desde backend
 
-  const fetchData = async (p = page) => {
+  const fetchData = useCallback(async (p = 0) => {
     setLoading(true);
     try {
       const desde = p * pageSize;
       const { data } = await api.get('/producservs', {
-        params: { desde, limite: pageSize }
+        params: { desde, limite: pageSize, search }
       });
 
       const flat = (data.producservs ?? []).map((x) => ({
@@ -59,9 +63,12 @@ const ProductTable = forwardRef(function ProductTable({ onEdit }, ref) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [pageSize, search]);
 
-  useEffect(() => { fetchData(0); }, []);
+  useEffect(() => {
+    fetchData(0);
+    setPage(0);
+  }, [search, fetchData]);
 
   useImperativeHandle(ref, () => ({
     refresh: () => fetchData(page),

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,7 +5,7 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import App from './App.jsx';
 import { themes } from './themes.js';
 
-const Root = () => {
+export const Root = () => {
   // Intentamos recuperar el tema guardado, si no existe usamos 'blue'
   const [themeName, setThemeName] = useState(() => {
     return localStorage.getItem('themeName') || 'blue';

--- a/frontend/src/pages/LoginForm.jsx
+++ b/frontend/src/pages/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import {
   Box,
   Button,
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { postLogin } from "../api/rutaUsuarios"; // tu helper original
-import fondoLogo from "../assets/logo.png"; // 🖼 asegurate de tener esta imagen en src/assets/
+// import fondoLogo from "../assets/logo.png"; // 🖼 asegurate de tener esta imagen en src/assets/
 
 const LoginForm = () => {
   const navigate = useNavigate();
@@ -32,18 +32,18 @@ const LoginForm = () => {
     if (token) {
       navigate("/");
     }
-  }, []);
+  }, [navigate]);
 
-  const logout = () => {
+  const logout = useCallback(() => {
     localStorage.clear();
     setIsLoggedIn(false);
     navigate("/login");
-  };
+  }, [navigate]);
 
-  const resetTimer = () => {
+  const resetTimer = useCallback(() => {
     clearTimeout(window.inactivityTimeout);
     window.inactivityTimeout = setTimeout(logout, 600000); // 10 min
-  };
+  }, [logout]);
 
   useEffect(() => {
     window.addEventListener("mousemove", resetTimer);
@@ -53,7 +53,7 @@ const LoginForm = () => {
       window.removeEventListener("keydown", resetTimer);
       clearTimeout(window.inactivityTimeout);
     };
-  }, []);
+  }, [resetTimer]);
 
   const handleChange = (e) => {
     setFormValues({ ...formValues, [e.target.name]: e.target.value });

--- a/frontend/src/pages/ProductsPage.jsx
+++ b/frontend/src/pages/ProductsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Stack, Button, Typography } from '@mui/material';
+import { Stack, Button, Typography, TextField } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ProductTable from '../components/ProductTable.jsx';
 import ProductFormDialog from '../components/ProductFormDialog.jsx';
@@ -7,22 +7,33 @@ import ProductFormDialog from '../components/ProductFormDialog.jsx';
 export default function ProductsPage() {
   const [open, setOpen] = React.useState(false);
   const [rowToEdit, setRowToEdit] = React.useState(null);
+  const [search, setSearch] = React.useState('');
   const tableRef = React.useRef(null);
 
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Productos</Typography>
 
-      <Button
-        variant="contained"
-        startIcon={<AddIcon />}
-        onClick={() => { setRowToEdit(null); setOpen(true); }}
-      >
-        Nuevo producto
-      </Button>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <TextField
+          label="Buscar"
+          variant="outlined"
+          size="small"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => { setRowToEdit(null); setOpen(true); }}
+        >
+          Nuevo producto
+        </Button>
+      </Stack>
 
       <ProductTable
         ref={tableRef}
+        search={search}
         onEdit={(row) => {
           setRowToEdit(row);
           setOpen(true);


### PR DESCRIPTION
## Summary
- add query-based search filter for products
- expose search box on products page with backend integration
- fix various lint warnings

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ab6cf7e0f88321af03973322456a47