### PR TITLE
Remove product search from Products page

### DIFF
--- a/frontend/src/pages/ProductsPage.jsx
+++ b/frontend/src/pages/ProductsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Stack, Button, Typography, TextField } from '@mui/material';
+import { Stack, Button, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ProductTable from '../components/ProductTable.jsx';
 import ProductFormDialog from '../components/ProductFormDialog.jsx';
@@ -7,33 +7,22 @@ import ProductFormDialog from '../components/ProductFormDialog.jsx';
 export default function ProductsPage() {
   const [open, setOpen] = React.useState(false);
   const [rowToEdit, setRowToEdit] = React.useState(null);
-  const [search, setSearch] = React.useState('');
   const tableRef = React.useRef(null);
 
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Productos</Typography>
 
-      <Stack direction="row" spacing={2} alignItems="center">
-        <TextField
-          label="Buscar"
-          variant="outlined"
-          size="small"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={() => { setRowToEdit(null); setOpen(true); }}
-        >
-          Nuevo producto
-        </Button>
-      </Stack>
+      <Button
+        variant="contained"
+        startIcon={<AddIcon />}
+        onClick={() => { setRowToEdit(null); setOpen(true); }}
+      >
+        Nuevo producto
+      </Button>
 
       <ProductTable
         ref={tableRef}
-        search={search}
         onEdit={(row) => {
           setRowToEdit(row);
           setOpen(true);


### PR DESCRIPTION
## Summary
- remove product search TextField and state from ProductsPage
- simplify button layout to only show the "Nuevo producto" button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abd67bdfac8321be421eb141638acb