### PR TITLE
refactor: simplify ProductTable server filters

### DIFF
--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -26,7 +26,7 @@ function CustomFooter({ totalCount = 0 }) {
   );
 }
 
-const ProductTable = forwardRef(function ProductTable({ onEdit, search = '' }, ref) {
+const ProductTable = forwardRef(function ProductTable({ onEdit }, ref) {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -40,7 +40,7 @@ const ProductTable = forwardRef(function ProductTable({ onEdit, search = '' }, r
     try {
       const desde = p * pageSize;
       const { field, value, operator } = model.items[0] || {};
-      const params = { desde, limite: pageSize, search };
+      const params = { desde, limite: pageSize };
       if (field && value !== undefined) {
         params.searchField = field;
         params.searchValue = value;
@@ -72,12 +72,12 @@ const ProductTable = forwardRef(function ProductTable({ onEdit, search = '' }, r
       setLoading(false);
     }
 
-  }, [pageSize, search, filterModel]);
+  }, [pageSize, filterModel]);
 
   useEffect(() => {
     fetchData(0);
     setPage(0);
-  }, [search, fetchData]);
+  }, [fetchData]);
 
   useImperativeHandle(ref, () => ({
     refresh: () => fetchData(page),


### PR DESCRIPTION
## Summary
- remove unused `search` prop from `ProductTable`
- send only basic pagination and active filter params in product fetch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae17f0149c8321ae9ab5fcc11aa873