### PR TITLE
feat: add unidadNombre alias and new sort fields

### DIFF
--- a/backend/server/rutas/producserv.js
+++ b/backend/server/rutas/producserv.js
@@ -69,6 +69,10 @@ router.get('/producservs', asyncHandler(async (req, res) => {
     'rubroNombre',
     'marcaNombre',
     'unidaddemedidaNombre',
+    'unidadNombre',
+    'tipo',
+    'iva',
+    'activo',
   ];
   const sf = allowedSortFields.includes(sortField) ? sortField : 'descripcion';
   const sortOpt = { [sf]: sortOrder === 'desc' ? -1 : 1 };
@@ -93,6 +97,7 @@ router.get('/producservs', asyncHandler(async (req, res) => {
         rubroNombre: '$rubro.rubro',
         marcaNombre: '$marca.marca',
         unidaddemedidaNombre: '$unidaddemedida.unidaddemedida',
+        unidadNombre: '$unidaddemedida.unidaddemedida',
       },
     },
     { $sort: sortOpt },


### PR DESCRIPTION
## Summary
- support sorting by tipo, iva, activo, and unidadNombre
- expose unidadNombre alongside existing unidaddemedidaNombre alias

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af916725cc8321b84da5f4c8daaf3b