### PR TITLE
Add Comandas page to dashboard routes

### DIFF
--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import DashboardLayout from './layouts/DashboardLayout';
 import ClientsPage from './pages/ClientsPage';
 import ProductsPage from './pages/ProductsPage.jsx';
+import ComandasPage from './pages/ComandasPage.jsx';
 import LoginForm from './pages/LoginForm';
 import PrivateRoute from './components/PrivateRoute';
 
@@ -19,6 +20,7 @@ export default function AppRoutes({ themeName, setThemeName }) {
       >
         <Route path="clients" element={<ClientsPage />} />
         <Route path="/products" element={<ProductsPage />} />
+        <Route path="comandas" element={<ComandasPage />} />
         {/* Otras rutas aquí */}
       </Route>
     </Routes>

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+export default function ComandasPage() {
+  return <Typography variant="h6">Comandas</Typography>;
+}
+


### PR DESCRIPTION
## Summary
- add ComandasPage component
- register `/comandas` route in dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `curl -I http://localhost:5173/comandas`


------
https://chatgpt.com/codex/tasks/task_e_68b07ce762648321965b4bc044557421