### PR TITLE
feat: resumen de comanda

### DIFF
--- a/frontend/src/components/ResumenComanda.jsx
+++ b/frontend/src/components/ResumenComanda.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Typography, List, ListItem, ListItemText, TextField, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+export default function ResumenComanda({ items = [], dispatch }) {
+  const handleQtyChange = (codprod, lista, cantidad) => {
+    const qty = Number(cantidad);
+    if (qty > 0) {
+      dispatch({ type: 'update', payload: { codprod, lista, cantidad: qty } });
+    }
+  };
+
+  const handleRemove = (codprod, lista) => {
+    dispatch({ type: 'remove', payload: { codprod, lista } });
+  };
+
+  return (
+    <Box sx={{ minWidth: 260 }}>
+      <Typography variant="h6" gutterBottom>Resumen</Typography>
+      <List>
+        {items.map((item) => (
+          <ListItem
+            key={`${item.codprod}-${item.lista}`}
+            secondaryAction={
+              <IconButton edge="end" onClick={() => handleRemove(item.codprod, item.lista)}>
+                <DeleteIcon />
+              </IconButton>
+            }
+          >
+            <ListItemText
+              primary={item.descripcion || item.codprod}
+              secondary={`Lista: ${item.lista} Precio: $${item.precio}`}
+            />
+            <TextField
+              type="number"
+              size="small"
+              value={item.cantidad}
+              onChange={(e) => handleQtyChange(item.codprod, item.lista, e.target.value)}
+              inputProps={{ min: 1 }}
+              sx={{ width: 64, ml: 2 }}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- useReducer to manage cart items and merge duplicates
- add ResumenComanda component with quantity editing and removal
- show order summary alongside product grid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1130e2f8883219f2a76200f2a12ac