### PR TITLE
feat: show product stock

### DIFF
--- a/frontend/src/components/ProductoItem.jsx
+++ b/frontend/src/components/ProductoItem.jsx
@@ -55,6 +55,13 @@ export default function ProductoItem({ producto, listas = [], defaultLista = '',
       )}
       <CardContent>
         <Typography variant="subtitle1" gutterBottom>{producto.descripcion}</Typography>
+        <Typography
+          variant="body2"
+          color={producto.stkactual === 0 ? 'warning.main' : 'text.secondary'}
+          sx={{ mb: 1 }}
+        >
+          Stock: {producto.stkactual}
+        </Typography>
         <TextField
           label="Cantidad"
           type="number"


### PR DESCRIPTION
## Summary
- display available stock and warn when empty in product item card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b260349f888321946691ec3485ff1c