### PR TITLE
feat: add product search

### DIFF
--- a/backend/server/rutas/producserv.js
+++ b/backend/server/rutas/producserv.js
@@ -19,6 +19,7 @@ router.get('/producservs', asyncHandler(async (req, res) => {
     searchField,
     searchValue,
     operator,
+    search,
     sortField,
     sortOrder,
   } = req.query;
@@ -27,6 +28,17 @@ router.get('/producservs', asyncHandler(async (req, res) => {
   const limit = Math.min(toNumber(limite, 10), 50); // tope por consulta
 
   const conditions = [];
+
+  // Búsqueda general por descripción o código
+  if (search) {
+    const regex = new RegExp(search, 'i');
+    conditions.push({
+      $or: [
+        { descripcion: { $regex: regex } },
+        { codprod: search },
+      ],
+    });
+  }
 
   // Filtro específico (desde la grilla MUI)
   if (searchField && searchValue) {

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -63,10 +63,7 @@ export default function ComandasPage() {
           limite: pageSize,
           desde: (page - 1) * pageSize,
         };
-        if (busqueda) {
-          params.searchField = 'descripcion';
-          params.searchValue = busqueda;
-        }
+        if (busqueda) params.search = busqueda;
         if (rubroSel) params.rubro = rubroSel;
         if (listaSel) params.lista = listaSel;
         const { data } = await api.get('/producservs', { params });


### PR DESCRIPTION
## Summary
- add search param to product service endpoint with $or on description and codprod
- send search value from Comandas page

## Testing
- `npm test` (backend) *(fails: no test specified)*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b263f597988321841a4a182d506e13