### PR TITLE
feat: confirm order from cart

### DIFF
--- a/frontend/src/components/ResumenComanda.jsx
+++ b/frontend/src/components/ResumenComanda.jsx
@@ -99,15 +99,17 @@ export default function ResumenComanda({
           InputProps={{ readOnly: true }}
         />
       </Box>
-      <Button
-        variant="contained"
-        fullWidth
-        sx={{ mt: 2 }}
-        onClick={onConfirm}
-        disabled={!clienteSel}
-      >
-        Confirmar
-      </Button>
+      {onConfirm && (
+        <Button
+          variant="contained"
+          fullWidth
+          sx={{ mt: 2 }}
+          onClick={onConfirm}
+          disabled={!clienteSel}
+        >
+          Confirmar
+        </Button>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add handler and button to confirm comandas
- clear cart and reset filters after posting new comanda
- show confirm button in summary only when handler provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4cfb089ac8321bee19654e5757488