### PR TITLE
feat(print): add currency formatting for comanda

### DIFF
--- a/frontend/src/components/ComandaPrintView.jsx
+++ b/frontend/src/components/ComandaPrintView.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@mui/material';
+
+export default function ComandaPrintView({ items = [] }) {
+  const currencyFormatter = new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+  });
+
+  const total = items.reduce((sum, item) => sum + item.precio * item.cantidad, 0);
+
+  return (
+    <Box>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Producto</TableCell>
+            <TableCell align="right">Precio</TableCell>
+            <TableCell align="right">Cantidad</TableCell>
+            <TableCell align="right">Subtotal</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.codprod}>
+              <TableCell>{item.descripcion || item.codprod}</TableCell>
+              <TableCell align="right">
+                {currencyFormatter.format(item.precio)}
+              </TableCell>
+              <TableCell align="right">{item.cantidad}</TableCell>
+              <TableCell align="right">
+                {currencyFormatter.format(item.precio * item.cantidad)}
+              </TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell colSpan={3} align="right">
+              <Typography variant="subtitle2">Total</Typography>
+            </TableCell>
+            <TableCell align="right">
+              <Typography variant="subtitle2">
+                {currencyFormatter.format(total)}
+              </Typography>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- format comanda print view prices and totals using ARS currency
- reorder print view columns to Producto, Precio, Cantidad, Subtotal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b658383fe08321917b6801f944aa41