### PR TITLE
feat(frontend): disable empty comanda submission

### DIFF
--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -81,6 +81,8 @@ export default function ComandasPage() {
   };
   const [items, dispatch] = useReducer(itemsReducer, []);
 
+  const canSubmit = items.length > 0 && clienteSel && !isSaving;
+
   useEffect(() => {
     const fetchFilters = async () => {
       try {
@@ -464,7 +466,7 @@ export default function ComandasPage() {
       <Button
         variant="contained"
         onClick={handlePrintClick}
-        disabled={isSaving}
+        disabled={!canSubmit}
       >
         Imprimir Comanda
       </Button>


### PR DESCRIPTION
## Summary
- avoid printing comanda when cart is empty or no client selected

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b65a337ae4832199ae467d266f934c