### PR TITLE
feat: add framer-motion animations

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-table": "^8.21.3",
         "axios": "^1.6.8",
         "dayjs": "^1.11.10",
+        "framer-motion": "^11.18.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.23.1",
@@ -3063,6 +3064,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3511,6 +3539,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4106,6 +4149,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.6.8",
     "dayjs": "^1.11.10",
+    "framer-motion": "^11.18.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.23.1",

--- a/frontend/src/components/ResumenComanda.jsx
+++ b/frontend/src/components/ResumenComanda.jsx
@@ -12,6 +12,7 @@ import {
   Button,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export default function ResumenComanda({
   items = [],
@@ -65,30 +66,43 @@ export default function ResumenComanda({
             <TableCell align="right">Acciones</TableCell>
           </TableRow>
         </TableHead>
-        <TableBody>
-          {items.map((item) => (
-            <TableRow key={`${item.codprod}-${item.lista}`}>
-              <TableCell>{item.descripcion || item.codprod}</TableCell>
-              <TableCell>{listas.find((l) => l._id === item.lista)?.lista || item.lista}</TableCell>
-              <TableCell align="right">${item.precio}</TableCell>
-              <TableCell align="right">
-                <TextField
-                  type="number"
-                  size="small"
-                  value={item.cantidad}
-                  onChange={(e) => handleQtyChange(item.codprod, item.lista, e.target.value)}
-                  inputProps={{ min: 1, max: item.stock }}
-                  sx={{ width: 64 }}
-                />
-              </TableCell>
-              <TableCell align="right">${item.precio * item.cantidad}</TableCell>
-              <TableCell align="right">
-                <IconButton edge="end" onClick={() => handleRemove(item.codprod, item.lista)}>
-                  <DeleteIcon />
-                </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
+        <TableBody component={motion.tbody}>
+          <AnimatePresence>
+            {items.map((item) => (
+              <TableRow
+                key={`${item.codprod}-${item.lista}`}
+                component={motion.tr}
+                initial={{ opacity: 0, y: -5 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -5 }}
+                transition={{ duration: 0.2 }}
+              >
+                <TableCell>{item.descripcion || item.codprod}</TableCell>
+                <TableCell>
+                  {listas.find((l) => l._id === item.lista)?.lista || item.lista}
+                </TableCell>
+                <TableCell align="right">${item.precio}</TableCell>
+                <TableCell align="right">
+                  <TextField
+                    type="number"
+                    size="small"
+                    value={item.cantidad}
+                    onChange={(e) => handleQtyChange(item.codprod, item.lista, e.target.value)}
+                    inputProps={{ min: 1, max: item.stock }}
+                    sx={{ width: 64 }}
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  ${item.precio * item.cantidad}
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton edge="end" onClick={() => handleRemove(item.codprod, item.lista)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </AnimatePresence>
         </TableBody>
       </Table>
       <Box mt={2} display="flex" justifyContent="flex-end">

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -22,6 +22,7 @@ import {
   CircularProgress,
   Snackbar,
 } from '@mui/material';
+import { motion, AnimatePresence } from 'framer-motion';
 import ProductoItem from '../components/ProductoItem.jsx';
 import ResumenComanda from '../components/ResumenComanda.jsx';
 import api from '../api/axios.js';
@@ -391,62 +392,76 @@ export default function ComandasPage() {
           </ToggleButtonGroup>
           {viewMode === 'grid' ? (
             <Grid container spacing={2}>
-              {productos.map((p) => {
-                const agregado = items
-                  .filter((i) => i.codprod === p._id)
-                  .reduce((sum, i) => sum + i.cantidad, 0);
-                return (
-                  <Grid
-                    item
-                    xs={12}
-                    sm={6}
-                    md={4}
-                    lg={3}
-                    key={p._id}
-                    id={`prod-${p._id}`}
-                  >
-                    <ProductoItem
-                      producto={p}
-                      listas={listas}
-                      defaultLista={listaSel}
-                      onAdd={handleAdd}
-                      focused={focusedProdId === p._id}
-                      stockDisponible={p.stkactual - agregado}
-                    />
-                  </Grid>
-                );
-              })}
+              <AnimatePresence>
+                {productos.map((p) => {
+                  const agregado = items
+                    .filter((i) => i.codprod === p._id)
+                    .reduce((sum, i) => sum + i.cantidad, 0);
+                  return (
+                    <Grid
+                      item
+                      xs={12}
+                      sm={6}
+                      md={4}
+                      lg={3}
+                      key={p._id}
+                      id={`prod-${p._id}`}
+                      component={motion.div}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -10 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <ProductoItem
+                        producto={p}
+                        listas={listas}
+                        defaultLista={listaSel}
+                        onAdd={handleAdd}
+                        focused={focusedProdId === p._id}
+                        stockDisponible={p.stkactual - agregado}
+                      />
+                    </Grid>
+                  );
+                })}
+              </AnimatePresence>
             </Grid>
           ) : (
             <List>
-              {productos.map((p) => {
-                const agregado = items
-                  .filter((i) => i.codprod === p._id)
-                  .reduce((sum, i) => sum + i.cantidad, 0);
-                const stockDisp = p.stkactual - agregado;
-                return (
-                  <ListItem
-                    key={p._id}
-                    id={`prod-${p._id}`}
-                    divider
-                    selected={focusedProdId === p._id}
-                    secondaryAction={
-                      <Button
-                        variant="contained"
-                        onClick={() => handleQuickAdd(p)}
-                        disabled={!listaSel || stockDisp <= 0}
-                      >
-                        Agregar
-                      </Button>
-                    }
-                  >
-                    <ListItemText
-                      primary={p.descripcion}
-                      secondary={`Stock: ${stockDisp}`}
-                    />
-                  </ListItem>
-                );
-              })}
+              <AnimatePresence>
+                {productos.map((p) => {
+                  const agregado = items
+                    .filter((i) => i.codprod === p._id)
+                    .reduce((sum, i) => sum + i.cantidad, 0);
+                  const stockDisp = p.stkactual - agregado;
+                  return (
+                    <ListItem
+                      key={p._id}
+                      id={`prod-${p._id}`}
+                      divider
+                      selected={focusedProdId === p._id}
+                      secondaryAction={
+                        <Button
+                          variant="contained"
+                          onClick={() => handleQuickAdd(p)}
+                          disabled={!listaSel || stockDisp <= 0}
+                        >
+                          Agregar
+                        </Button>
+                      }
+                      component={motion.li}
+                      initial={{ opacity: 0, x: -10 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -10 }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <ListItemText
+                        primary={p.descripcion}
+                        secondary={`Stock: ${stockDisp}`}
+                      />
+                    </ListItem>
+                  );
+                })}
+              </AnimatePresence>
             </List>
           )}
           <Pagination
@@ -456,12 +471,24 @@ export default function ComandasPage() {
             sx={{ mt: 2, alignSelf: 'center' }}
           />
         </Box>
-        <ResumenComanda
-          items={items}
-          listas={listas}
-          dispatch={dispatch}
-          clienteSel={clienteSel}
-        />
+        <AnimatePresence>
+          {items.length > 0 && (
+            <motion.div
+              key="resumen"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 20 }}
+              transition={{ duration: 0.2 }}
+            >
+              <ResumenComanda
+                items={items}
+                listas={listas}
+                dispatch={dispatch}
+                clienteSel={clienteSel}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </Stack>
       <Button
         variant="contained"


### PR DESCRIPTION
## Summary
- install framer-motion for frontend
- animate product list and cart summary with subtle transitions
- add animated rows in cart summary table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7136fad648321b172dbec13a19839