### PR TITLE
feat: enhance comanda print dialog

### DIFF
--- a/frontend/src/components/ComandaPrintView.jsx
+++ b/frontend/src/components/ComandaPrintView.jsx
@@ -7,21 +7,36 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  Stack,
 } from '@mui/material';
 
-export default function ComandaPrintView({ items = [] }) {
+export default function ComandaPrintView({ items = [], nrodecomanda, cliente }) {
   const currencyFormatter = new Intl.NumberFormat('es-AR', {
     style: 'currency',
     currency: 'ARS',
   });
 
-  const total = items.reduce((sum, item) => sum + item.precio * item.cantidad, 0);
+  const total = items.reduce(
+    (sum, item) => sum + (Number(item.precio) || 0) * (Number(item.cantidad) || 0),
+    0,
+  );
 
   return (
-    <Box>
+    <Box className="print-area">
+      <Stack spacing={1} sx={{ mb: 1 }}>
+        {nrodecomanda && (
+          <Typography variant="subtitle1">
+            Nº de comanda: {nrodecomanda}
+          </Typography>
+        )}
+        <Typography variant="subtitle1">
+          Cliente: {cliente?.razonsocial || 'Consumidor Final'}
+        </Typography>
+      </Stack>
       <Table size="small">
         <TableHead>
           <TableRow>
+            <TableCell>Código</TableCell>
             <TableCell>Producto</TableCell>
             <TableCell align="right">Precio</TableCell>
             <TableCell align="right">Cantidad</TableCell>
@@ -29,20 +44,27 @@ export default function ComandaPrintView({ items = [] }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {items.map((item) => (
-            <TableRow key={item.codprod}>
-              <TableCell>{item.descripcion || item.codprod}</TableCell>
-              <TableCell align="right">
-                {currencyFormatter.format(item.precio)}
-              </TableCell>
-              <TableCell align="right">{item.cantidad}</TableCell>
-              <TableCell align="right">
-                {currencyFormatter.format(item.precio * item.cantidad)}
-              </TableCell>
-            </TableRow>
-          ))}
+          {items.map((item) => {
+            const codigo = item.codigo || item.codprod;
+            const precio = Number(item.precio) || 0;
+            const cantidad = Number(item.cantidad) || 0;
+            const subtotal = precio * cantidad;
+            return (
+              <TableRow key={codigo}>
+                <TableCell>{codigo}</TableCell>
+                <TableCell>{item.nombre}</TableCell>
+                <TableCell align="right">
+                  {currencyFormatter.format(precio)}
+                </TableCell>
+                <TableCell align="right">{cantidad}</TableCell>
+                <TableCell align="right">
+                  {currencyFormatter.format(subtotal)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
           <TableRow>
-            <TableCell colSpan={3} align="right">
+            <TableCell colSpan={4} align="right">
               <Typography variant="subtitle2">Total</Typography>
             </TableCell>
             <TableCell align="right">

--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -135,7 +135,13 @@ export default function HistorialComandas() {
       <Dialog open={!!selected} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>Comanda {selected?.nrodecomanda}</DialogTitle>
         <DialogContent>
-          {selected && <ComandaPrintView items={toPrintItems(selected)} />}
+          {selected && (
+            <ComandaPrintView
+              nrodecomanda={selected.nrodecomanda}
+              cliente={selected.cliente}
+              items={toPrintItems(selected)}
+            />
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => window.print()} startIcon={<PrintIcon />}>Imprimir</Button>

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -26,6 +26,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import ProductoItem from '../components/ProductoItem.jsx';
 import ResumenComanda from '../components/ResumenComanda.jsx';
 import api from '../api/axios.js';
+import ComandaPrintView from '../components/ComandaPrintView.jsx';
+import { useNavigate } from 'react-router-dom';
 
 const ESTADO_A_PREPARAR = '62200265c811f41820d8bda9';
 
@@ -54,6 +56,7 @@ export default function ComandasPage() {
   const [printDialogOpen, setPrintDialogOpen] = useState(false);
   const [savedComanda, setSavedComanda] = useState(null);
   const scanBufferRef = useRef('');
+  const navigate = useNavigate();
   const itemsReducer = (state, action) => {
     switch (action.type) {
       case 'add': {
@@ -505,21 +508,11 @@ export default function ComandasPage() {
             <CircularProgress />
           )}
           {!isSaving && savedComanda && (
-            <Stack spacing={2} sx={{ mt: 1 }}>
-              <Typography variant="subtitle1">
-                Nº de comanda: {savedComanda.nrodecomanda}
-              </Typography>
-              <List>
-                {(savedComanda.items || []).map((item, idx) => (
-                  <ListItem key={idx} disablePadding>
-                    <ListItemText
-                      primary={item.descripcion || item.codprod}
-                      secondary={`Cantidad: ${item.cantidad}`}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </Stack>
+            <ComandaPrintView
+              nrodecomanda={savedComanda.nrodecomanda}
+              cliente={savedComanda.cliente}
+              items={savedComanda.items || []}
+            />
           )}
           {!isSaving && !savedComanda && !saveError && (
             <Typography sx={{ mt: 1 }}>
@@ -530,7 +523,7 @@ export default function ComandasPage() {
         <DialogActions>
           <Button onClick={() => setPrintDialogOpen(false)}>Cerrar</Button>
           <Button
-            onClick={() => window.print()}
+            onClick={() => navigate('/historial-comandas')}
             disabled={isSaving || !savedComanda?.nrodecomanda}
           >
             Imprimir


### PR DESCRIPTION
## Summary
- add header with client information and detailed table to comanda print view
- replace print dialog action to navigate to historial
- wire updated print view in historial de comandas

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75ad2ae4483219b21ac324662930a