### PR TITLE
Show client info in comanda print dialog

### DIFF
--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -291,7 +291,7 @@ export default function ComandasPage() {
     try {
       setIsSaving(true);
       const { data } = await api.post('/comandas', payload);
-      setSavedComanda(data.comanda);
+      setSavedComanda({ ...data.comanda, cliente: clienteSel });
       dispatch({ type: 'clear' });
       setBusqueda('');
       setRubroSel('');

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -505,21 +505,26 @@ export default function ComandasPage() {
             <CircularProgress />
           )}
           {!isSaving && savedComanda && (
-            <Stack spacing={2} sx={{ mt: 1 }}>
-              <Typography variant="subtitle1">
-                Nº de comanda: {savedComanda.nrodecomanda}
-              </Typography>
-              <List>
-                {(savedComanda.items || []).map((item, idx) => (
-                  <ListItem key={idx} disablePadding>
-                    <ListItemText
-                      primary={item.descripcion || item.codprod}
-                      secondary={`Cantidad: ${item.cantidad}`}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </Stack>
+            <Box className="print-area">
+              <Stack spacing={2} sx={{ mt: 1 }}>
+                <Typography variant="subtitle1">
+                  Nº de comanda: {savedComanda.nrodecomanda}
+                </Typography>
+                <Typography variant="subtitle1">
+                  Cliente: {savedComanda?.cliente?.razonsocial || clienteSel?.razonsocial}
+                </Typography>
+                <List>
+                  {(savedComanda.items || []).map((item, idx) => (
+                    <ListItem key={idx} disablePadding>
+                      <ListItemText
+                        primary={item.descripcion || item.codprod}
+                        secondary={`Cantidad: ${item.cantidad}`}
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </Stack>
+            </Box>
           )}
           {!isSaving && !savedComanda && !saveError && (
             <Typography sx={{ mt: 1 }}>


### PR DESCRIPTION
## Summary
- Display client name in the print dialog
- Wrap comanda details in a dedicated print-area box

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b762376b988321a17721409619d397