### PR TITLE
feat(frontend): show product codes and subtotals in print view

### DIFF
--- a/frontend/src/components/ComandaPrintView.jsx
+++ b/frontend/src/components/ComandaPrintView.jsx
@@ -9,19 +9,23 @@ import {
   TableCell,
 } from '@mui/material';
 
-export default function ComandaPrintView({ items = [] }) {
+export default function ComandaPrintView({ items = [], showTotal = true }) {
   const currencyFormatter = new Intl.NumberFormat('es-AR', {
     style: 'currency',
     currency: 'ARS',
   });
 
-  const total = items.reduce((sum, item) => sum + item.precio * item.cantidad, 0);
+  const total = items.reduce(
+    (sum, item) => sum + Number(item.precio) * Number(item.cantidad),
+    0,
+  );
 
   return (
     <Box>
       <Table size="small">
         <TableHead>
           <TableRow>
+            <TableCell>Código</TableCell>
             <TableCell>Producto</TableCell>
             <TableCell align="right">Precio</TableCell>
             <TableCell align="right">Cantidad</TableCell>
@@ -29,28 +33,34 @@ export default function ComandaPrintView({ items = [] }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {items.map((item) => (
-            <TableRow key={item.codprod}>
-              <TableCell>{item.descripcion || item.codprod}</TableCell>
-              <TableCell align="right">
-                {currencyFormatter.format(item.precio)}
+          {items.map((item) => {
+            const subtotal = Number(item.precio) * Number(item.cantidad);
+            return (
+              <TableRow key={item.codigo ?? item.codprod}>
+                <TableCell>{item.codigo ?? item.codprod}</TableCell>
+                <TableCell>{item.descripcion || item.codprod}</TableCell>
+                <TableCell align="right">
+                  {currencyFormatter.format(Number(item.precio))}
+                </TableCell>
+                <TableCell align="right">{item.cantidad}</TableCell>
+                <TableCell align="right">
+                  {currencyFormatter.format(subtotal)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+          {showTotal && (
+            <TableRow>
+              <TableCell colSpan={4} align="right">
+                <Typography variant="subtitle2">Total</Typography>
               </TableCell>
-              <TableCell align="right">{item.cantidad}</TableCell>
               <TableCell align="right">
-                {currencyFormatter.format(item.precio * item.cantidad)}
+                <Typography variant="subtitle2">
+                  {currencyFormatter.format(total)}
+                </Typography>
               </TableCell>
             </TableRow>
-          ))}
-          <TableRow>
-            <TableCell colSpan={3} align="right">
-              <Typography variant="subtitle2">Total</Typography>
-            </TableCell>
-            <TableCell align="right">
-              <Typography variant="subtitle2">
-                {currencyFormatter.format(total)}
-              </Typography>
-            </TableCell>
-          </TableRow>
+          )}
         </TableBody>
       </Table>
     </Box>


### PR DESCRIPTION
## Summary
- display product code column in print view and rows
- compute subtotals and totals as numbers with ARS currency formatting
- add `showTotal` prop to optionally render final total row

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76d5343d08321aa0f8c9e555df3a8