### PR TITLE
feat: improve comanda print view

### DIFF
--- a/frontend/src/components/ComandaPrintView.jsx
+++ b/frontend/src/components/ComandaPrintView.jsx
@@ -9,14 +9,15 @@ import {
   TableCell,
 } from '@mui/material';
 
-export default function ComandaPrintView({ items = [], showTotal = true }) {
+function ComandaPrintView({ items = [], showTotal = false }) {
   const currencyFormatter = new Intl.NumberFormat('es-AR', {
     style: 'currency',
     currency: 'ARS',
   });
 
   const total = items.reduce(
-    (sum, item) => sum + Number(item.precio) * Number(item.cantidad),
+    (sum, item) =>
+      sum + (Number(item.monto) || 0) * (Number(item.cantidad) || 0),
     0,
   );
 
@@ -33,16 +34,18 @@ export default function ComandaPrintView({ items = [], showTotal = true }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {items.map((item) => {
-            const subtotal = Number(item.precio) * Number(item.cantidad);
+          {items.map((item, idx) => {
+            const precio = Number(item.monto) || 0;
+            const cantidad = Number(item.cantidad) || 0;
+            const subtotal = precio * cantidad;
             return (
-              <TableRow key={item.codigo ?? item.codprod}>
-                <TableCell>{item.codigo ?? item.codprod}</TableCell>
-                <TableCell>{item.descripcion || item.codprod}</TableCell>
+              <TableRow key={item.codprod?.codprod ?? idx}>
+                <TableCell>{item.codprod?.codprod ?? ''}</TableCell>
+                <TableCell>{item.codprod?.descripcion ?? ''}</TableCell>
                 <TableCell align="right">
-                  {currencyFormatter.format(Number(item.precio))}
+                  {currencyFormatter.format(precio)}
                 </TableCell>
-                <TableCell align="right">{item.cantidad}</TableCell>
+                <TableCell align="right">{cantidad}</TableCell>
                 <TableCell align="right">
                   {currencyFormatter.format(subtotal)}
                 </TableCell>
@@ -66,3 +69,5 @@ export default function ComandaPrintView({ items = [], showTotal = true }) {
     </Box>
   );
 }
+
+export default ComandaPrintView;

--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
 import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import EditIcon from '@mui/icons-material/Edit';
@@ -59,14 +67,6 @@ export default function HistorialComandas() {
     handleView(row);
     setTimeout(() => window.print(), 100);
   };
-
-  const toPrintItems = (com) =>
-    com.items.map((i) => ({
-      codprod: i.codprod?._id ?? i.codprod,
-      descripcion: i.codprod?.descripcion ?? '',
-      precio: i.monto,
-      cantidad: i.cantidad,
-    }));
 
   const columns = [
     { field: 'nrodecomanda', headerName: 'Número', width: 100 },
@@ -135,7 +135,17 @@ export default function HistorialComandas() {
       <Dialog open={!!selected} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>Comanda {selected?.nrodecomanda}</DialogTitle>
         <DialogContent>
-          {selected && <ComandaPrintView items={toPrintItems(selected)} />}
+          {selected && (
+            <Box>
+              <Typography variant="subtitle1">
+                Nº de comanda: {selected.nrodecomanda}
+              </Typography>
+              <Typography variant="subtitle1">
+                Cliente: {selected.codcli?.razonsocial || ''}
+              </Typography>
+              <ComandaPrintView items={selected.items || []} showTotal />
+            </Box>
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => window.print()} startIcon={<PrintIcon />}>Imprimir</Button>


### PR DESCRIPTION
## Summary
- allow hiding total in comanda print view with `showTotal` prop
- pass `showTotal` when displaying a historical comanda
- render print dialog using API item fields and show comanda info

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76face0ac832193012e4529d4ca41