### PR TITLE
feat: handle stock error without alerts

### DIFF
--- a/frontend/src/components/ResumenComanda.jsx
+++ b/frontend/src/components/ResumenComanda.jsx
@@ -20,6 +20,7 @@ export default function ResumenComanda({
   dispatch,
   clienteSel,
   onConfirm,
+  onStockError,
 }) {
   const handleQtyChange = (codprod, lista, cantidad) => {
     const qty = Number(cantidad);
@@ -30,11 +31,12 @@ export default function ResumenComanda({
       .reduce((sum, i) => sum + i.cantidad, 0);
     const total = otros + qty;
     if (total > item.stock) {
-      alert('Stock insuficiente');
+      if (onStockError) onStockError('Stock insuficiente');
       return;
     }
     if (qty > 0) {
       dispatch({ type: 'update', payload: { codprod, lista, cantidad: qty } });
+      if (onStockError) onStockError(null);
     }
   };
 

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -54,6 +54,7 @@ export default function ComandasPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [missingProducts, setMissingProducts] = useState([]);
+  const [stockError, setStockError] = useState('');
   const [printDialogOpen, setPrintDialogOpen] = useState(false);
   const [savedComanda, setSavedComanda] = useState(null);
   const navigate = useNavigate();
@@ -338,6 +339,10 @@ export default function ComandasPage() {
     navigate('/historial-comandas');
   };
 
+  const handleStockError = (msg) => {
+    setStockError(msg || '');
+  };
+
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Comandas</Typography>
@@ -499,11 +504,15 @@ export default function ComandasPage() {
                 listas={listas}
                 dispatch={dispatch}
                 clienteSel={clienteSel}
+                onStockError={handleStockError}
               />
             </motion.div>
           )}
         </AnimatePresence>
       </Stack>
+      {stockError && (
+        <Typography color="error">{stockError}</Typography>
+      )}
       <Button
         variant="contained"
         onClick={handlePrintClick}


### PR DESCRIPTION
## Summary
- remove alert from order summary quantity change
- bubble stock error to parent via callback and show inline message

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc880eab3083218e3f25c53c51a95b