### PR TITLE
Validate and format date column in HistorialComandas

### DIFF
--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -63,7 +63,16 @@ export default function HistorialComandas() {
       field: 'fecha',
       headerName: 'Fecha',
       width: 140,
-      valueGetter: (params) => new Date(params.value).toLocaleDateString('es-AR'),
+      valueGetter: (params) => {
+        const date =
+          params.value instanceof Date ? params.value : new Date(params.value);
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return '-';
+        }
+        return date.toLocaleDateString('es-AR', {
+          timeZone: 'America/Argentina/Tucuman',
+        });
+      },
     },
     { field: 'clienteNombre', headerName: 'Cliente', flex: 1 },
     { field: 'estadoNombre', headerName: 'Estado', width: 120 },


### PR DESCRIPTION
## Summary
- validate date column and format with locale-specific time zone

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f402e3c0832190a82e550ff2912e