### PR TITLE
fix: guard total column formatter

### DIFF
--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -96,7 +96,8 @@ export default function HistorialComandas() {
       headerName: 'Total',
       width: 120,
       type: 'number',
-      valueFormatter: (p) => currencyFormatter.format(p.value),
+      valueFormatter: (p) =>
+        currencyFormatter.format(Number(p.value) || 0),
     },
     {
       field: 'actions',


### PR DESCRIPTION
## Summary
- handle invalid values in HistorialComandas total column formatter

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b42948f883219a9359d26986182d