### PR TITLE
fix(frontend): format fecha column in order history

### DIFF
--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -86,6 +86,9 @@ export default function HistorialComandas() {
         }
         return date.toLocaleDateString('es-AR', {
           timeZone: 'America/Argentina/Tucuman',
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
         });
       },
     },


### PR DESCRIPTION
## Summary
- format HistorialComandas fecha column using es-AR locale with explicit day, month and year options

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b8dc10608321933c7edbab14527b