### PR TITLE
Format fecha column with dd-mm-yyyy

### DIFF
--- a/frontend/src/components/HistorialComandas.jsx
+++ b/frontend/src/components/HistorialComandas.jsx
@@ -78,18 +78,12 @@ export default function HistorialComandas() {
       field: 'fecha',
       headerName: 'Fecha',
       width: 140,
-      valueGetter: (params) => {
-        const date =
-          params.value instanceof Date ? params.value : new Date(params.value);
-        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-          return '-';
-        }
-        return date.toLocaleDateString('es-AR', {
-          timeZone: 'America/Argentina/Tucuman',
-          day: '2-digit',
-          month: '2-digit',
-          year: 'numeric',
-        });
+      valueGetter: ({ row }) => {
+        const d = new Date(row.fecha);
+        if (Number.isNaN(d)) return '-';
+        const dd = String(d.getDate()).padStart(2, '0');
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        return `${dd}-${mm}-${d.getFullYear()}`;
       },
     },
     { field: 'clienteNombre', headerName: 'Cliente', flex: 1 },


### PR DESCRIPTION
## Summary
- Format `fecha` column to `dd-mm-yyyy` using `valueGetter`
- Maintain API call and server-side pagination for command history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `curl http://localhost:3004/comandas/historial?page=1&pageSize=10` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c292dd148321a8d38c43d3e49099