### PR TITLE
chore: remove mongoose-auto-increment

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "jwt-encode": "^1.0.1",
         "mongodb": "^6.18.0",
         "mongoose": "^8.16.5",
-        "mongoose-auto-increment": "^5.0.1",
         "mongoose-sequence": "^6.0.1",
         "mongoose-unique-validator": "^4.0.1",
         "nodemon": "^3.1.10",
@@ -509,11 +508,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1078,17 +1072,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose-auto-increment": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-5.0.1.tgz",
-      "integrity": "sha512-fuSw0np0ZZXYjNBBrD6Wg0y70N0i5NhBuH3AIETTXCchaq45FeHpISoQ3fFbbdSFhfVEDRtg+hVxEDpFjdI2lw==",
-      "dependencies": {
-        "extend": "^3.0.0"
-      },
-      "peerDependencies": {
-        "mongoose": "^4.1.12"
       }
     },
     "node_modules/mongoose-sequence": {
@@ -2150,11 +2133,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2552,14 +2530,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
-      }
-    },
-    "mongoose-auto-increment": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-5.0.1.tgz",
-      "integrity": "sha512-fuSw0np0ZZXYjNBBrD6Wg0y70N0i5NhBuH3AIETTXCchaq45FeHpISoQ3fFbbdSFhfVEDRtg+hVxEDpFjdI2lw==",
-      "requires": {
-        "extend": "^3.0.0"
       }
     },
     "mongoose-sequence": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,6 @@
     "jwt-encode": "^1.0.1",
     "mongodb": "^6.18.0",
     "mongoose": "^8.16.5",
-    "mongoose-auto-increment": "^5.0.1",
     "mongoose-sequence": "^6.0.1",
     "mongoose-unique-validator": "^4.0.1",
     "nodemon": "^3.1.10",

--- a/backend/server/modelos/cliente.js
+++ b/backend/server/modelos/cliente.js
@@ -1,7 +1,5 @@
 const mongoose = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
-const autoIncrement = require("mongoose-auto-increment");
-
 const AutoIncrement = require("mongoose-sequence")(mongoose);
 let Schema = mongoose.Schema;
 

--- a/backend/server/modelos/comanda.js
+++ b/backend/server/modelos/comanda.js
@@ -1,7 +1,5 @@
 const mongoose = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
-const autoIncrement = require("mongoose-auto-increment");
-
 const AutoIncrement = require("mongoose-sequence")(mongoose);
 let Schema = mongoose.Schema;
 


### PR DESCRIPTION
## Summary
- drop unused mongoose-auto-increment dependency
- clean Comanda and Cliente models to stop requiring mongoose-auto-increment

## Testing
- `node --check server/modelos/comanda.js`
- `node --check server/modelos/cliente.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dbdca1ac8321b39cc01891e6f85d