### PR TITLE
Rely on mongoose-sequence for comanda numbers

### DIFF
--- a/backend/server/rutas/comanda.js
+++ b/backend/server/rutas/comanda.js
@@ -240,8 +240,9 @@ router.post('/comandas',  asyncHandler(async (req, res) => {
   let comandaDB;
   try {
     await session.withTransaction(async () => {
+      // El número de comanda es asignado automáticamente por el plugin
+      // mongoose-sequence; no se debe enviar desde el cliente.
       const comanda = new Comanda({
-        nrodecomanda: body.nrodecomanda,
         codcli: body.codcli,
         fecha: body.fecha,
         codestado: body.codestado,

--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -282,6 +282,8 @@ export default function ComandasPage() {
       alert('Seleccione un cliente');
       return;
     }
+    // El número de comanda se genera en el backend mediante mongoose-sequence,
+    // por lo que no se envía desde el cliente.
     const payload = {
       codcli: clienteSel._id,
       fecha: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Remove manual `nrodecomanda` assignment in comanda creation
- Note that `nrodecomanda` is generated server-side and not sent by the client

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c6ded9bcb08321a8b32c7b38ed6192