### PR TITLE
Use transactional counter for comanda numbers

### DIFF
--- a/backend/server/modelos/comanda.js
+++ b/backend/server/modelos/comanda.js
@@ -1,6 +1,5 @@
 const mongoose = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
-const AutoIncrement = require("mongoose-sequence")(mongoose);
 let Schema = mongoose.Schema;
 
 // Subdocumento para los ítems de la comanda
@@ -90,8 +89,5 @@ comandaSchema.plugin(uniqueValidator, {
   message: "{PATH} debe ser único",
 });
 
-comandaSchema.plugin(AutoIncrement, {
-  inc_field: "nrodecomanda",
-});
 
 module.exports = mongoose.model("Comanda", comandaSchema);

--- a/backend/server/modelos/counter.js
+++ b/backend/server/modelos/counter.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const counterSchema = new mongoose.Schema({
+  nrodecomanda: {
+    type: Number,
+    default: 0,
+  },
+});
+
+module.exports = mongoose.model('Counter', counterSchema);

--- a/backend/server/rutas/comanda.js
+++ b/backend/server/rutas/comanda.js
@@ -7,6 +7,7 @@ const Comanda = require('../modelos/comanda');
 const Producserv = require('../modelos/producserv');
 const Stock = require('../modelos/stock');
 const Tipomovimiento = require('../modelos/tipomovimiento');
+const Counter = require('../modelos/counter');
 const {
   verificaToken,
   verificaAdmin_role,
@@ -240,8 +241,13 @@ router.post('/comandas',  asyncHandler(async (req, res) => {
   let comandaDB;
   try {
     await session.withTransaction(async () => {
+      const counter = await Counter.findOneAndUpdate(
+        {},
+        { $inc: { nrodecomanda: 1 } },
+        { new: true, upsert: true, session }
+      );
       const comanda = new Comanda({
-        nrodecomanda: body.nrodecomanda,
+        nrodecomanda: counter.nrodecomanda,
         codcli: body.codcli,
         fecha: body.fecha,
         codestado: body.codestado,


### PR DESCRIPTION
## Summary
- Add Counter model to track last comanda number
- Increment counter and assign order number in comanda creation within a transaction
- Drop auto-increment plugin from Comanda schema

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c6e0ba16ec832181c6aab66cb2d499