### PR TITLE
feat: add documentos API with autoincremental numbering

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "jwt-encode": "^1.0.1",
+        "moment-timezone": "^0.5.48",
         "mongodb": "^6.18.0",
         "mongoose": "^8.16.5",
         "mongoose-sequence": "^6.0.1",
@@ -991,6 +992,27 @@
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -2480,6 +2502,19 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+    },
+    "moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "requires": {
+        "moment": "^2.29.4"
       }
     },
     "mongodb": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "jwt-encode": "^1.0.1",
+    "moment-timezone": "^0.5.48",
     "mongodb": "^6.18.0",
     "mongoose": "^8.16.5",
     "mongoose-sequence": "^6.0.1",

--- a/backend/server/modelos/documento.js
+++ b/backend/server/modelos/documento.js
@@ -1,0 +1,142 @@
+const mongoose = require('mongoose');
+const moment = require('moment-timezone');
+const AutoIncrementFactory = require('mongoose-sequence');
+
+const AutoIncrement = AutoIncrementFactory(mongoose);
+const { Schema } = mongoose;
+
+const ZONA_ARGENTINA = 'America/Argentina/Buenos_Aires';
+const TIPOS_DOCUMENTO = ['R', 'NR', 'AJ'];
+
+const toArgDate = (value) => (value ? moment.tz(value, ZONA_ARGENTINA).toDate() : value);
+const padSecuencia = (value) => String(value ?? 0).padStart(8, '0');
+const padPrefijo = (value) => {
+  if (value === undefined || value === null || value === '') return undefined;
+  const str = String(value).trim();
+  if (/^\d{1,4}$/.test(str)) return str.padStart(4, '0');
+  return str;
+};
+
+const itemSchema = new Schema({
+  cantidad: {
+    type: Number,
+    required: [true, 'La cantidad es obligatoria'],
+    validate: {
+      validator: (valor) => typeof valor === 'number' && !Number.isNaN(valor) && valor > 0,
+      message: 'La cantidad debe ser un número positivo',
+    },
+  },
+  producto: {
+    type: Schema.Types.ObjectId,
+    ref: 'Producserv',
+    required: [true, 'El producto es obligatorio'],
+  },
+  codprod: {
+    type: String,
+    trim: true,
+    required: [true, 'El código de producto es obligatorio'],
+  },
+}, { _id: false });
+
+const documentoSchema = new Schema({
+  prefijo: {
+    type: String,
+    default: '0001',
+    set: padPrefijo,
+    validate: {
+      validator: (valor) => /^\d{4}$/.test(valor),
+      message: 'El prefijo debe componerse de cuatro dígitos',
+    },
+  },
+  tipo: {
+    type: String,
+    required: [true, 'El tipo de documento es obligatorio'],
+    enum: {
+      values: TIPOS_DOCUMENTO,
+      message: 'Tipo de documento inválido',
+    },
+  },
+  secuencia: Number,
+  NrodeDocumento: {
+    type: String,
+    unique: true,
+    index: true,
+  },
+  proveedor: {
+    type: Schema.Types.ObjectId,
+    ref: 'Proveedor',
+    required: [true, 'El proveedor es obligatorio'],
+  },
+  fechaRemito: {
+    type: Date,
+    required: [true, 'La fecha del documento es obligatoria'],
+  },
+  fechaRegistro: {
+    type: Date,
+    default: () => toArgDate(new Date()),
+  },
+  usuario: {
+    type: Schema.Types.ObjectId,
+    ref: 'Usuario',
+    required: [true, 'El usuario es obligatorio'],
+  },
+  items: {
+    type: [itemSchema],
+    validate: {
+      validator: (items) => Array.isArray(items) && items.length > 0,
+      message: 'Debe incluir al menos un ítem de producto',
+    },
+  },
+  observaciones: {
+    type: String,
+    trim: true,
+  },
+  activo: {
+    type: Boolean,
+    default: true,
+  },
+}, {
+  timestamps: false,
+  versionKey: false,
+});
+
+documentoSchema.plugin(AutoIncrement, {
+  inc_field: 'secuencia',
+  reference_fields: ['tipo'],
+});
+
+documentoSchema.pre('validate', function(next) {
+  if (!this.prefijo) {
+    this.prefijo = '0001';
+  }
+  if (this.fechaRemito) {
+    this.fechaRemito = toArgDate(this.fechaRemito);
+  }
+  if (!this.fechaRegistro) {
+    this.fechaRegistro = toArgDate(new Date());
+  } else {
+    this.fechaRegistro = toArgDate(this.fechaRegistro);
+  }
+  next();
+});
+
+documentoSchema.pre('save', function(next) {
+  const tipo = this.tipo;
+  if (!TIPOS_DOCUMENTO.includes(tipo)) {
+    return next(new Error('Tipo de documento inválido'));
+  }
+  this.NrodeDocumento = `${this.prefijo}${tipo}${padSecuencia(this.secuencia)}`;
+  next();
+});
+
+documentoSchema.index({ tipo: 1, secuencia: 1 }, { unique: true });
+
+documentoSchema.statics.TIPOS_DOCUMENTO = TIPOS_DOCUMENTO;
+documentoSchema.statics.ZONA_ARGENTINA = ZONA_ARGENTINA;
+
+documentoSchema.methods.toJSON = function() {
+  const obj = this.toObject();
+  return obj;
+};
+
+module.exports = mongoose.model('Documento', documentoSchema);

--- a/backend/server/rutas/documentos.js
+++ b/backend/server/rutas/documentos.js
@@ -1,0 +1,266 @@
+// rutas/documentos.js — CRUD de Remitos, Notas de Recepción y Ajustes
+// ---------------------------------------------------------------------------
+// Node.js v22.17.1 + Mongoose v8.16.5
+
+const express = require('express');
+const mongoose = require('mongoose');
+const Documento = require('../modelos/documento');
+const Proveedor = require('../modelos/proveedor');
+const Producserv = require('../modelos/producserv');
+const { verificaToken } = require('../middlewares/autenticacion');
+
+const router = express.Router();
+
+// -----------------------------------------------------------------------------
+// Helpers ----------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+const toNumber = (value, def = 0) => Number(value ?? def);
+const isValidObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
+const normalizeText = (value) => value
+  ? value
+      .toString()
+      .trim()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toUpperCase()
+  : '';
+const normalizeTipo = (tipo) => {
+  const map = {
+    R: 'R',
+    REMITO: 'R',
+    REMITOS: 'R',
+    NR: 'NR',
+    'NOTA DE RECEPCION': 'NR',
+    'NOTA DE RECEPCION NR': 'NR',
+    AJ: 'AJ',
+    AJUSTE: 'AJ',
+    'AJUSTE DE INVENTARIO': 'AJ',
+    AJUSTES: 'AJ',
+  };
+  const normalized = normalizeText(tipo);
+  return map[normalized] || null;
+};
+const normalizePrefijoInput = (prefijo) => {
+  if (prefijo === undefined || prefijo === null || prefijo === '') return undefined;
+  const cleaned = prefijo.toString().trim();
+  if (!/^\d{1,4}$/.test(cleaned)) return null;
+  return cleaned.padStart(4, '0');
+};
+const badRequest = (res, message) => res.status(400).json({ ok: false, err: { message } });
+const documentoPopulate = [
+  {
+    path: 'proveedor',
+    populate: [
+      { path: 'localidad', populate: { path: 'provincia' } },
+      { path: 'condicioniva' },
+    ],
+  },
+  { path: 'usuario', select: 'nombres apellidos email role' },
+  { path: 'items.producto', select: 'codprod descripcion tipo iva activo' },
+];
+const parseItems = async (rawItems = []) => {
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    const error = new Error('Debe incluir al menos un ítem de producto');
+    error.status = 400;
+    throw error;
+  }
+  const items = [];
+  const productosIds = new Set();
+  rawItems.forEach((item, index) => {
+    const cantidad = Number(item?.cantidad);
+    if (!Number.isFinite(cantidad) || cantidad <= 0) {
+      const error = new Error(`La cantidad del ítem ${index + 1} debe ser un número positivo`);
+      error.status = 400;
+      throw error;
+    }
+    const productoId = item?.producto || item?._id;
+    if (!isValidObjectId(productoId)) {
+      const error = new Error(`El producto del ítem ${index + 1} es inválido`);
+      error.status = 400;
+      throw error;
+    }
+    const codprod = item?.codprod;
+    if (!codprod || !codprod.toString().trim()) {
+      const error = new Error(`El código de producto es obligatorio en el ítem ${index + 1}`);
+      error.status = 400;
+      throw error;
+    }
+    productosIds.add(productoId.toString());
+    items.push({
+      cantidad,
+      producto: productoId,
+      codprod: codprod.toString().trim(),
+    });
+  });
+  const productos = await Producserv.find({ _id: { $in: [...productosIds] } })
+    .select('_id')
+    .lean()
+    .exec();
+  if (productos.length !== productosIds.size) {
+    const error = new Error('Uno o más productos referenciados no existen en la base de datos');
+    error.status = 400;
+    throw error;
+  }
+  return items;
+};
+
+// -----------------------------------------------------------------------------
+// 1. CREAR DOCUMENTO ------------------------------------------------------------
+// -----------------------------------------------------------------------------
+router.post('/documentos', [verificaToken], asyncHandler(async (req, res) => {
+  const body = req.body || {};
+  const tipo = normalizeTipo(body.tipo);
+  if (!tipo) return badRequest(res, 'Tipo de documento inválido. Use R, NR o AJ.');
+
+  const prefijo = normalizePrefijoInput(body.prefijo);
+  if (prefijo === null) return badRequest(res, 'El prefijo debe ser numérico de hasta 4 dígitos.');
+
+  if (!body.fechaRemito) return badRequest(res, 'La fecha de remito es obligatoria.');
+
+  const proveedorId = body.proveedor;
+  if (!isValidObjectId(proveedorId)) return badRequest(res, 'Proveedor inválido.');
+
+  const proveedor = await Proveedor.findById(proveedorId).select('_id').lean().exec();
+  if (!proveedor) return badRequest(res, 'El proveedor indicado no existe.');
+
+  const userId = req.usuario?._id;
+  if (!userId) return res.status(401).json({ ok: false, err: { message: 'Usuario no autenticado' } });
+
+  let items;
+  try {
+    items = await parseItems(body.items);
+  } catch (error) {
+    return res.status(error.status || 500).json({ ok: false, err: { message: error.message } });
+  }
+
+  const data = {
+    tipo,
+    proveedor: proveedorId,
+    fechaRemito: body.fechaRemito,
+    usuario: userId,
+    items,
+    observaciones: body.observaciones,
+  };
+  if (prefijo) data.prefijo = prefijo;
+
+  const documento = new Documento(data);
+  const documentoDB = await documento.save();
+  await documentoDB.populate(documentoPopulate);
+
+  res.status(201).json({ ok: true, documento: documentoDB });
+}));
+
+// -----------------------------------------------------------------------------
+// 2. LISTAR DOCUMENTOS ----------------------------------------------------------
+// -----------------------------------------------------------------------------
+router.get('/documentos', [verificaToken], asyncHandler(async (req, res) => {
+  const { desde = 0, limite = 50, tipo, proveedor, activo = 'true' } = req.query;
+  const query = {};
+
+  if (tipo) {
+    const tipoNormalizado = normalizeTipo(tipo);
+    if (!tipoNormalizado) return badRequest(res, 'Tipo de documento inválido en el filtro.');
+    query.tipo = tipoNormalizado;
+  }
+
+  if (proveedor) {
+    if (!isValidObjectId(proveedor)) return badRequest(res, 'Proveedor inválido en el filtro.');
+    query.proveedor = proveedor;
+  }
+
+  if (activo !== undefined) {
+    query.activo = !(activo === 'false' || activo === false);
+  }
+
+  const desdeNumber = toNumber(desde, 0);
+  const limiteNumber = toNumber(limite, 50);
+  const safeSkip = Number.isFinite(desdeNumber) ? Math.max(desdeNumber, 0) : 0;
+  const safeLimit = Number.isFinite(limiteNumber) ? Math.max(limiteNumber, 0) : 50;
+
+  const documentos = await Documento.find(query)
+    .skip(safeSkip)
+    .limit(safeLimit)
+    .sort({ fechaRegistro: -1 })
+    .populate(documentoPopulate)
+    .lean()
+    .exec();
+
+  const cantidad = await Documento.countDocuments(query);
+  res.json({ ok: true, documentos, cantidad });
+}));
+
+// -----------------------------------------------------------------------------
+// 3. OBTENER DOCUMENTO POR ID ---------------------------------------------------
+// -----------------------------------------------------------------------------
+router.get('/documentos/:id', [verificaToken], asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  if (!isValidObjectId(id)) return badRequest(res, 'Identificador inválido.');
+
+  const documento = await Documento.findById(id).populate(documentoPopulate).lean().exec();
+  if (!documento) return res.status(404).json({ ok: false, err: { message: 'Documento no encontrado' } });
+
+  res.json({ ok: true, documento });
+}));
+
+// -----------------------------------------------------------------------------
+// 4. ACTUALIZAR DOCUMENTO -------------------------------------------------------
+// -----------------------------------------------------------------------------
+router.put('/documentos/:id', [verificaToken], asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  if (!isValidObjectId(id)) return badRequest(res, 'Identificador inválido.');
+
+  const documento = await Documento.findById(id).exec();
+  if (!documento) return res.status(404).json({ ok: false, err: { message: 'Documento no encontrado' } });
+
+  const body = req.body || {};
+
+  if (body.tipo && normalizeTipo(body.tipo) !== documento.tipo) {
+    return badRequest(res, 'No se permite cambiar el tipo del documento una vez creado.');
+  }
+
+  if (body.prefijo !== undefined) {
+    const prefijoNormalizado = normalizePrefijoInput(body.prefijo);
+    if (prefijoNormalizado === null) return badRequest(res, 'El prefijo debe ser numérico de hasta 4 dígitos.');
+    if (prefijoNormalizado) documento.prefijo = prefijoNormalizado;
+  }
+
+  if (body.proveedor) {
+    if (!isValidObjectId(body.proveedor)) return badRequest(res, 'Proveedor inválido.');
+    const prov = await Proveedor.findById(body.proveedor).select('_id').lean().exec();
+    if (!prov) return badRequest(res, 'El proveedor indicado no existe.');
+    documento.proveedor = body.proveedor;
+  }
+
+  if (body.fechaRemito) {
+    documento.fechaRemito = body.fechaRemito;
+  }
+
+  if (Array.isArray(body.items)) {
+    let itemsActualizados;
+    try {
+      itemsActualizados = await parseItems(body.items);
+    } catch (error) {
+      return res.status(error.status || 500).json({ ok: false, err: { message: error.message } });
+    }
+    documento.items = itemsActualizados;
+  }
+
+  if (body.observaciones !== undefined) {
+    documento.observaciones = body.observaciones;
+  }
+
+  if (body.activo !== undefined) {
+    documento.activo = !(body.activo === 'false' || body.activo === false);
+  }
+
+  const documentoDB = await documento.save();
+  await documentoDB.populate(documentoPopulate);
+
+  res.json({ ok: true, documento: documentoDB });
+}));
+
+// -----------------------------------------------------------------------------
+module.exports = router;

--- a/backend/server/rutas/index.js
+++ b/backend/server/rutas/index.js
@@ -24,6 +24,7 @@ app.use(require("./ultimacomanda"));
 app.use(require("./tipomovimiento"));
 app.use(require("./invoice"));
 app.use(require("./remito"));
+app.use(require("./documentos"));
 
 app.use(require("./login"));
 module.exports = app;


### PR DESCRIPTION
## Summary
- create a Documento schema using mongoose-sequence to generate type-based correlatives and persist Argentina timezone dates
- add secured /documentos routes that validate proveedores/productos, build the composed NrodeDocumento and expose CRUD operations
- register the new router and add moment-timezone to the backend dependencies

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c89304687883218420d8e4aca6139a