### PR TITLE
Add auto-increment id for documento sequence

### DIFF
--- a/backend/server/modelos/documento.js
+++ b/backend/server/modelos/documento.js
@@ -1,0 +1,36 @@
+const mongoose = require("mongoose");
+const AutoIncrement = require("mongoose-sequence")(mongoose);
+
+const Schema = mongoose.Schema;
+
+const documentoSchema = new Schema(
+  {
+    tipo: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    secuencia: {
+      type: Number,
+    },
+    descripcion: {
+      type: String,
+      trim: true,
+    },
+    activo: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+documentoSchema.plugin(AutoIncrement, {
+  id: "documento_secuencia",
+  inc_field: "secuencia",
+  reference_fields: ["tipo"],
+});
+
+module.exports = mongoose.model("Documento", documentoSchema);


### PR DESCRIPTION
## Summary
- create the Documento schema with mongoose-sequence support
- configure the auto-increment plugin with a stable id so reference fields work when grouping by tipo

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c94870b8d8832192eaff27da79e27d