### PR TITLE
feat(frontend): add stock documents wizard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.18.0",
         "@mui/x-data-grid": "^8.9.1",
+        "@mui/x-date-pickers": "^8.11.2",
         "@tanstack/react-table": "^8.21.3",
         "axios": "^1.6.8",
         "dayjs": "^1.11.10",
@@ -276,9 +277,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1687,6 +1688,141 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.11.2.tgz",
+      "integrity": "sha512-izosRFdlo0Aq4nrQ2klOQBLB+yCX3bIlErF/gxZfaXK/kb8NToweZjhHdiyy+hr+VrxK0A71AWI6LkPyfG2WCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.2",
+        "@mui/x-internals": "8.11.2",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/types": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/utils": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.11.2.tgz",
+      "integrity": "sha512-3BFZ0Njgih+eWQBzSsdKEkRMlHtKRGFWz+/CGUrSBb5IApO0apkUSvG4v5augNYASsjksqWOXVlds7Wwznd0Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.2",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mui/x-internals": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.15.20",
     "@mui/material": "^5.18.0",
     "@mui/x-data-grid": "^8.9.1",
+    "@mui/x-date-pickers": "^8.11.2",
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.6.8",
     "dayjs": "^1.11.10",

--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -6,6 +6,7 @@ import ComandasPage from './pages/ComandasPage.jsx';
 import LoginForm from './pages/LoginForm';
 import PrivateRoute from './components/PrivateRoute';
 import HistorialComandas from './components/HistorialComandas.jsx';
+import DocumentsPage from './pages/DocumentsPage.jsx';
 
 export default function AppRoutes({ themeName, setThemeName }) {
   return (
@@ -22,6 +23,7 @@ export default function AppRoutes({ themeName, setThemeName }) {
         <Route path="clients" element={<ClientsPage />} />
         <Route path="/products" element={<ProductsPage />} />
         <Route path="comandas" element={<ComandasPage />} />
+        <Route path="/documents" element={<DocumentsPage />} />
         <Route path="/historial-comandas" element={<HistorialComandas />} />
         {/* Otras rutas aquí */}
       </Route>

--- a/frontend/src/api/documentos.js
+++ b/frontend/src/api/documentos.js
@@ -1,0 +1,20 @@
+import api from './axios';
+
+export const fetchDocumentos = (params = {}) =>
+  api.get('/documentos', { params });
+
+export const createDocumento = (payload) =>
+  api.post('/documentos', payload);
+
+export const fetchProveedores = (params = {}) =>
+  api.get('/proveedores', {
+    params: { limite: 500, ...params },
+  });
+
+export const fetchProductos = (params = {}) =>
+  api.get('/producservs', {
+    params: { limite: 100, ...params },
+  });
+
+export const updateProductoStock = (id, payload) =>
+  api.put(`/producservs/${id}`, payload);

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,9 +1,10 @@
 // src/components/PrivateRoute.jsx
 import React from "react";
 import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContextState.js";
 
 const PrivateRoute = ({ children }) => {
-  const token = localStorage.getItem("token");
+  const { token } = useAuth();
   return token ? children : <Navigate to="/login" replace />;
 };
 

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,73 @@
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import { AuthContext, AUTH_STATE_TEMPLATE } from './AuthContextState.js';
+
+const readAuthFromStorage = () => {
+  const token = localStorage.getItem('token');
+  const userId = localStorage.getItem('id');
+  const storedName = localStorage.getItem('usuario');
+  let userName = '';
+
+  if (storedName) {
+    try {
+      userName = JSON.parse(storedName);
+    } catch {
+      userName = storedName;
+    }
+  }
+
+  return {
+    token: token || null,
+    userId: userId || null,
+    userName: userName || '',
+  };
+};
+
+export const AuthProvider = ({ children }) => {
+  const [authState, setAuthState] = useState(() => ({
+    ...AUTH_STATE_TEMPLATE,
+    ...readAuthFromStorage(),
+  }));
+
+  const login = useCallback(({ token, user }) => {
+    if (token) localStorage.setItem('token', token);
+    if (user?._id) localStorage.setItem('id', user._id);
+    if (user?.nombres) localStorage.setItem('usuario', JSON.stringify(user.nombres));
+
+    setAuthState({
+      token: token || null,
+      userId: user?._id || null,
+      userName: user?.nombres || '',
+    });
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('id');
+    localStorage.removeItem('usuario');
+    setAuthState({ ...AUTH_STATE_TEMPLATE });
+  }, []);
+
+  const refreshAuth = useCallback(() => {
+    setAuthState({
+      ...AUTH_STATE_TEMPLATE,
+      ...readAuthFromStorage(),
+    });
+  }, []);
+
+  const value = useMemo(() => ({
+    ...authState,
+    login,
+    logout,
+    refreshAuth,
+  }), [authState, login, logout, refreshAuth]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/context/AuthContextState.js
+++ b/frontend/src/context/AuthContextState.js
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export const AUTH_STATE_TEMPLATE = {
+  token: null,
+  userId: null,
+  userName: '',
+};
+
+export const AuthContext = createContext({
+  ...AUTH_STATE_TEMPLATE,
+  login: () => {},
+  logout: () => {},
+  refreshAuth: () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -29,41 +29,40 @@ import SecurityIcon from '@mui/icons-material/Security';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import HistoryIcon from '@mui/icons-material/History';
+import DescriptionIcon from '@mui/icons-material/Description';
 import ThemeSelector from '../components/ThemeSelector.jsx';
 import Footer from '../components/Footer';
 import logo from '../assets/logo.png';
+import { useAuth } from '../context/AuthContextState.js';
 
 /* ----------------─ Menú lateral ─---------------- */
 const navItems = [
-  { label: 'Clientes', path: '/clients',   icon: <GroupIcon /> },
-  { label: 'Usuarios', path: '/users',     icon: <PeopleAltIcon /> },
-  { label: 'Productos', path: '/products',     icon: <Inventory2Icon /> }, // 👈 NUEVO
+  { label: 'Clientes', path: '/clients', icon: <GroupIcon /> },
+  { label: 'Usuarios', path: '/users', icon: <PeopleAltIcon /> },
+  { label: 'Productos', path: '/products', icon: <Inventory2Icon /> },
+  { label: 'Documentos', path: '/documents', icon: <DescriptionIcon /> },
   { label: 'Comandas', path: '/comandas', icon: <ReceiptLongIcon /> },
   { label: 'Historial', path: '/historial-comandas', icon: <HistoryIcon /> },
   { label: 'Permisos', path: '/permissions', icon: <SecurityIcon /> },
-  { label: 'Logística', path: '/logistics',  icon: <LocalShippingIcon /> },
+  { label: 'Logística', path: '/logistics', icon: <LocalShippingIcon /> },
 ];
 
 export default function DashboardLayout({ themeName, setThemeName }) {
   const [open, setOpen] = useState(false);
   const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false);
-  const [nombreUsuario, setNombreUsuario] = useState('');
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const { token, userName, logout } = useAuth();
 
   /* -------- Verifica token cada render -------- */
   useEffect(() => {
-    const token = localStorage.getItem('token');
     if (!token) navigate('/login');
-
-    const storedUser = localStorage.getItem('usuario');
-    if (storedUser) setNombreUsuario(JSON.parse(storedUser));
-  }, [navigate]);
+  }, [navigate, token]);
 
   /* -------- handlers logout -------- */
   const handleLogoutClick   = () => setConfirmLogoutOpen(true);
   const handleLogoutConfirm = () => {
-    localStorage.clear();
+    logout();
     navigate('/login');
   };
   const handleLogoutCancel  = () => setConfirmLogoutOpen(false);
@@ -83,7 +82,7 @@ export default function DashboardLayout({ themeName, setThemeName }) {
           </Typography>
 
           <Typography variant="body1" sx={{ mr: 2 }}>
-            {nombreUsuario}
+            {userName}
           </Typography>
 
           <ThemeSelector themeName={themeName} setThemeName={setThemeName} />

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import App from './App.jsx';
 import { themes } from './themes.js';
+import { AuthProvider } from './context/AuthContext.jsx';
 
 export const Root = () => {
   // Intentamos recuperar el tema guardado, si no existe usamos 'blue'
@@ -18,10 +19,12 @@ export const Root = () => {
 
   return (
     <BrowserRouter>
-      <ThemeProvider theme={themes[themeName]}>
-        <CssBaseline />
-        <App themeName={themeName} setThemeName={setThemeName} />
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider theme={themes[themeName]}>
+          <CssBaseline />
+          <App themeName={themeName} setThemeName={setThemeName} />
+        </ThemeProvider>
+      </AuthProvider>
     </BrowserRouter>
   );
 };

--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -1,0 +1,647 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  CircularProgress,
+  Grid,
+  IconButton,
+  MenuItem,
+  Paper,
+  Snackbar,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import 'dayjs/locale/es';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { useAuth } from '../context/AuthContextState.js';
+import {
+  createDocumento,
+  fetchDocumentos,
+  fetchProductos,
+  fetchProveedores,
+  updateProductoStock,
+} from '../api/documentos.js';
+
+const ARG_TIMEZONE = 'America/Argentina/Buenos_Aires';
+const DOCUMENT_TYPES = [
+  { value: 'R', label: 'Remito' },
+  { value: 'NR', label: 'Nota de Recepción' },
+  { value: 'AJ', label: 'Ajuste de Inventario' },
+];
+
+const steps = ['Seleccioná el tipo', 'Completa los datos'];
+
+const createEmptyItem = () => ({
+  cantidad: '',
+  producto: null,
+  codprod: '',
+});
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export default function DocumentsPage() {
+  const { userId } = useAuth();
+  const [activeStep, setActiveStep] = useState(0);
+  const [selectedType, setSelectedType] = useState('');
+  const [formState, setFormState] = useState({
+    tipo: '',
+    prefijo: '0001',
+    sequenceManual: '',
+    documentNumberManual: '',
+    fechaRemito: dayjs().tz(ARG_TIMEZONE),
+    proveedor: null,
+  });
+  const [autoSequenceDisplay, setAutoSequenceDisplay] = useState('');
+  const [autoDocumentNumber, setAutoDocumentNumber] = useState('');
+  const [items, setItems] = useState([createEmptyItem()]);
+  const [providers, setProviders] = useState([]);
+  const [products, setProducts] = useState([]);
+  const [loadingProviders, setLoadingProviders] = useState(false);
+  const [loadingProducts, setLoadingProducts] = useState(false);
+  const [loadingDocumentMeta, setLoadingDocumentMeta] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState({});
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+
+  const showSnackbar = useCallback((message, severity = 'success') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const handleSnackbarClose = useCallback(() => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const loadProviders = useCallback(async () => {
+    setLoadingProviders(true);
+    try {
+      const { data } = await fetchProveedores();
+      setProviders((data?.proveedores || []).sort((a, b) => a.razonsocial.localeCompare(b.razonsocial)));
+    } catch (error) {
+      console.error(error);
+      showSnackbar('No se pudo cargar la lista de proveedores.', 'error');
+    } finally {
+      setLoadingProviders(false);
+    }
+  }, [showSnackbar]);
+
+  const loadProducts = useCallback(async () => {
+    setLoadingProducts(true);
+    try {
+      const { data } = await fetchProductos({ limite: 200, sortField: 'descripcion' });
+      setProducts(data?.producservs || []);
+    } catch (error) {
+      console.error(error);
+      showSnackbar('No se pudo cargar la lista de productos.', 'error');
+    } finally {
+      setLoadingProducts(false);
+    }
+  }, [showSnackbar]);
+
+  useEffect(() => {
+    if (activeStep === 1) {
+      loadProviders();
+      loadProducts();
+    }
+  }, [activeStep, loadProducts, loadProviders]);
+
+  const prepareAutomaticSequence = useCallback(async (tipo) => {
+    setLoadingDocumentMeta(true);
+    const defaultPrefijo = '0001';
+    const typeInitial = tipo === 'NR' ? 'N' : 'A';
+    let prefijo = defaultPrefijo;
+    let nextSequence = 1;
+
+    try {
+      const { data } = await fetchDocumentos({ tipo, limite: 1 });
+      const lastDocument = data?.documentos?.[0];
+      if (lastDocument) {
+        prefijo = lastDocument.prefijo || defaultPrefijo;
+        nextSequence = Number(lastDocument.secuencia || 0) + 1;
+      }
+    } catch (error) {
+      console.error(error);
+      showSnackbar('No se pudo consultar el último número. Se usarán valores por defecto.', 'warning');
+    } finally {
+      setFormState((prev) => ({
+        ...prev,
+        prefijo,
+      }));
+      setAutoSequenceDisplay(`${typeInitial}${prefijo}`);
+      setAutoDocumentNumber(`${prefijo}${tipo}${String(nextSequence).padStart(8, '0')}`);
+      setLoadingDocumentMeta(false);
+    }
+  }, [showSnackbar]);
+
+  const resetForm = useCallback(() => {
+    setFormState({
+      tipo: '',
+      prefijo: '0001',
+      sequenceManual: '',
+      documentNumberManual: '',
+      fechaRemito: dayjs().tz(ARG_TIMEZONE),
+      proveedor: null,
+    });
+    setItems([createEmptyItem()]);
+    setAutoSequenceDisplay('');
+    setAutoDocumentNumber('');
+    setSelectedType('');
+    setErrors({});
+  }, []);
+
+  const handleTypeContinue = useCallback(async () => {
+    if (!selectedType) {
+      setErrors({ tipo: 'Seleccioná un tipo de documento válido.' });
+      return;
+    }
+
+    setErrors({});
+    setItems([createEmptyItem()]);
+    setFormState((prev) => ({
+      ...prev,
+      tipo: selectedType,
+      sequenceManual: '',
+      documentNumberManual: '',
+      fechaRemito: dayjs().tz(ARG_TIMEZONE),
+      proveedor: null,
+    }));
+    setAutoSequenceDisplay('');
+    setAutoDocumentNumber('');
+    setActiveStep(1);
+
+    if (selectedType !== 'R') {
+      await prepareAutomaticSequence(selectedType);
+    }
+  }, [prepareAutomaticSequence, selectedType]);
+
+  const handleBack = useCallback(() => {
+    setActiveStep(0);
+  }, []);
+
+  const handleItemChange = useCallback((index, field, value) => {
+    setItems((prev) => prev.map((item, idx) => {
+      if (idx !== index) return item;
+      if (field === 'producto') {
+        const codprod = value?.codprod || '';
+        return { ...item, producto: value, codprod: codprod || item.codprod };
+      }
+      return { ...item, [field]: value };
+    }));
+  }, []);
+
+  const addItemRow = useCallback(() => {
+    setItems((prev) => [...prev, createEmptyItem()]);
+  }, []);
+
+  const removeItemRow = useCallback((index) => {
+    setItems((prev) => prev.filter((_, idx) => idx !== index));
+  }, []);
+
+  const itemErrors = useMemo(() => errors.items || [], [errors.items]);
+
+  const validateForm = useCallback(() => {
+    const validation = {};
+
+    if (!formState.proveedor) {
+      validation.proveedor = 'Debes seleccionar un proveedor.';
+    }
+
+    if (!formState.fechaRemito) {
+      validation.fechaRemito = 'La fecha es obligatoria.';
+    }
+
+    if (formState.tipo === 'R') {
+      if (!formState.sequenceManual || !/^[A-Za-z][0-9]{4}$/.test(formState.sequenceManual)) {
+        validation.sequenceManual = 'Usá una letra seguida de cuatro dígitos (ej. R0001).';
+      }
+      if (!formState.documentNumberManual || !/^\d{1,8}$/.test(formState.documentNumberManual)) {
+        validation.documentNumberManual = 'El número debe tener hasta 8 dígitos.';
+      }
+    }
+
+    const rowsErrors = items.map((item) => ({
+      cantidad: !item.cantidad || Number(item.cantidad) <= 0 ? 'Ingresá una cantidad positiva.' : '',
+      producto: item.producto ? '' : 'Seleccioná un producto.',
+      codprod: item.codprod ? '' : 'Ingresá el código asociado.',
+    }));
+
+    if (rowsErrors.some((row) => row.cantidad || row.producto || row.codprod)) {
+      validation.items = rowsErrors;
+      validation.itemsMessage = 'Revisá los ítems cargados.';
+    }
+
+    if (!items.length) {
+      validation.itemsMessage = 'Agregá al menos un ítem.';
+    }
+
+    return validation;
+  }, [formState.documentNumberManual, formState.proveedor, formState.sequenceManual, formState.tipo, formState.fechaRemito, items]);
+
+  const handleSave = useCallback(async () => {
+    const validation = validateForm();
+    setErrors(validation);
+
+    if (Object.keys(validation).length > 0) {
+      showSnackbar('Revisá los campos destacados antes de grabar.', 'error');
+      return;
+    }
+
+    const payloadItems = items.map((item) => ({
+      cantidad: Number(item.cantidad),
+      producto: item.producto._id,
+      codprod: item.codprod.trim(),
+    }));
+
+    const fechaFormatted = formState.fechaRemito
+      ? dayjs(formState.fechaRemito).tz(ARG_TIMEZONE).format('YYYY-MM-DD')
+      : null;
+
+    const payload = {
+      tipo: formState.tipo,
+      prefijo: formState.prefijo,
+      proveedor: formState.proveedor._id,
+      fechaRemito: fechaFormatted,
+      items: payloadItems,
+    };
+
+    if (formState.tipo === 'R') {
+      payload.prefijo = formState.sequenceManual ? formState.sequenceManual.slice(1) : formState.prefijo;
+      payload.numeroManual = formState.documentNumberManual;
+    }
+
+    if (userId) {
+      payload.usuario = userId;
+    }
+
+    setSaving(true);
+
+    try {
+      const { data } = await createDocumento(payload);
+      const documentoCreado = data?.documento;
+      const predictedNumber = formState.tipo === 'R'
+        ? formState.documentNumberManual
+        : autoDocumentNumber;
+      const docNumber = documentoCreado?.NrodeDocumento || predictedNumber;
+
+      showSnackbar(
+        docNumber
+          ? `Documento ${docNumber} guardado. Actualizando stock...`
+          : 'Documento guardado. Actualizando stock...',
+        'success',
+      );
+
+      const updatesByProduct = new Map();
+      items.forEach((item) => {
+        if (!item.producto) return;
+        const key = item.producto._id;
+        const current = updatesByProduct.get(key) || { cantidad: 0, producto: item.producto };
+        current.cantidad += Number(item.cantidad) || 0;
+        updatesByProduct.set(key, current);
+      });
+
+      const updateResults = await Promise.allSettled(
+        Array.from(updatesByProduct.values()).map(({ cantidad, producto }) => {
+          const currentStock = Number(producto.stkactual ?? 0);
+          const nuevoStock = currentStock - cantidad;
+          return updateProductoStock(producto._id, { stkactual: nuevoStock });
+        })
+      );
+
+      const failed = updateResults.filter((result) => result.status === 'rejected');
+      if (failed.length) {
+        showSnackbar(
+          docNumber
+            ? `Documento ${docNumber} guardado, pero hubo errores al actualizar el stock.`
+            : 'El documento se guardó, pero hubo errores al actualizar el stock.',
+          'warning',
+        );
+      } else if (updatesByProduct.size) {
+        showSnackbar(
+          docNumber
+            ? `Documento ${docNumber} guardado y stock actualizado correctamente.`
+            : 'Stock actualizado correctamente.',
+          'success',
+        );
+      } else {
+        showSnackbar(
+          docNumber
+            ? `Documento ${docNumber} guardado correctamente.`
+            : 'Documento guardado correctamente.',
+          'success',
+        );
+      }
+
+      resetForm();
+      setActiveStep(0);
+    } catch (error) {
+      console.error(error);
+      const message = error?.response?.data?.err?.message || 'No se pudo guardar el documento.';
+      showSnackbar(message, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [autoDocumentNumber, formState.documentNumberManual, formState.fechaRemito, formState.prefijo, formState.proveedor, formState.sequenceManual, formState.tipo, items, resetForm, showSnackbar, userId, validateForm]);
+
+  const sequenceHelperText = useMemo(() => {
+    if (formState.tipo === 'R') {
+      return 'Ejemplo: R0001';
+    }
+    return 'Se completa automáticamente según el tipo seleccionado.';
+  }, [formState.tipo]);
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
+      <Stack spacing={3}>
+        <Typography variant="h5">Nuevo documento de stock</Typography>
+
+        <Stepper activeStep={activeStep} alternativeLabel>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+
+        {activeStep === 0 && (
+          <Paper sx={{ p: 3 }}>
+            <Stack spacing={3}>
+              <Typography variant="subtitle1">
+                Seleccioná el tipo de movimiento que deseas registrar
+              </Typography>
+              <TextField
+                select
+                fullWidth
+                label="Tipo de documento"
+                value={selectedType}
+                onChange={(event) => setSelectedType(event.target.value)}
+                error={Boolean(errors.tipo)}
+                helperText={errors.tipo || 'Las opciones se validan con el backend.'}
+              >
+                {DOCUMENT_TYPES.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <Stack direction="row" justifyContent="flex-end" spacing={2}>
+                <Button
+                  variant="contained"
+                  onClick={handleTypeContinue}
+                  disabled={loadingDocumentMeta}
+                >
+                  Continuar
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        )}
+
+        {activeStep === 1 && (
+          <Paper sx={{ p: 3 }}>
+            <Stack spacing={3}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Datos del documento</Typography>
+                <Button
+                  startIcon={<ArrowBackIcon />}
+                  onClick={handleBack}
+                  color="secondary"
+                >
+                  Volver
+                </Button>
+              </Stack>
+
+              {loadingDocumentMeta && (
+                <Alert severity="info">Consultando numeración disponible en el backend…</Alert>
+              )}
+
+              <Grid container spacing={2}>
+                <Grid item xs={12} md={6}>
+                  <Autocomplete
+                    options={providers}
+                    loading={loadingProviders}
+                    value={formState.proveedor}
+                    onChange={(_, newValue) => setFormState((prev) => ({ ...prev, proveedor: newValue }))}
+                    isOptionEqualToValue={(option, value) => option._id === value?._id}
+                    getOptionLabel={(option) => option?.razonsocial || ''}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Proveedor"
+                        error={Boolean(errors.proveedor)}
+                        helperText={errors.proveedor || ''}
+                        InputProps={{
+                          ...params.InputProps,
+                          endAdornment: (
+                            <>
+                              {loadingProviders ? <CircularProgress color="inherit" size={18} /> : null}
+                              {params.InputProps.endAdornment}
+                            </>
+                          ),
+                        }}
+                      />
+                    )}
+                  />
+                </Grid>
+
+                <Grid item xs={12} md={6}>
+                  <DatePicker
+                    label="Fecha del documento"
+                    value={formState.fechaRemito}
+                    format="DD/MM/YYYY"
+                    onChange={(value) => setFormState((prev) => ({ ...prev, fechaRemito: value }))}
+                    slotProps={{
+                      textField: {
+                        fullWidth: true,
+                        error: Boolean(errors.fechaRemito),
+                        helperText: errors.fechaRemito || '',
+                      },
+                    }}
+                  />
+                </Grid>
+
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Secuencia"
+                    fullWidth
+                    value={formState.tipo === 'R' ? formState.sequenceManual : autoSequenceDisplay}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, sequenceManual: event.target.value.toUpperCase() }))}
+                    inputProps={{ maxLength: 5 }}
+                    disabled={formState.tipo !== 'R'}
+                    helperText={
+                      formState.tipo === 'R' && errors.sequenceManual
+                        ? errors.sequenceManual
+                        : sequenceHelperText
+                    }
+                    error={formState.tipo === 'R' && Boolean(errors.sequenceManual)}
+                  />
+                </Grid>
+
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Número de documento"
+                    fullWidth
+                    value={formState.tipo === 'R' ? formState.documentNumberManual : autoDocumentNumber}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, documentNumberManual: event.target.value }))}
+                    inputProps={{ maxLength: 8, inputMode: 'numeric' }}
+                    disabled={formState.tipo !== 'R'}
+                    helperText={
+                      formState.tipo === 'R' && errors.documentNumberManual
+                        ? errors.documentNumberManual
+                        : formState.tipo === 'R'
+                          ? 'Hasta 8 dígitos numéricos.'
+                          : 'Generado automáticamente desde el backend.'
+                    }
+                    error={formState.tipo === 'R' && Boolean(errors.documentNumberManual)}
+                  />
+                </Grid>
+
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Usuario"
+                    fullWidth
+                    value={userId || ''}
+                    disabled
+                    helperText="Se enviará automáticamente en la carga."
+                  />
+                </Grid>
+              </Grid>
+
+              {errors.itemsMessage && (
+                <Alert severity="warning">{errors.itemsMessage}</Alert>
+              )}
+
+              <Box>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
+                  <Typography variant="subtitle1">Ítems</Typography>
+                  <Button
+                    startIcon={<AddCircleIcon />}
+                    onClick={addItemRow}
+                    variant="outlined"
+                  >
+                    Agregar ítem
+                  </Button>
+                </Stack>
+                <TableContainer component={Paper} variant="outlined">
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell width="15%">Cantidad</TableCell>
+                        <TableCell width="45%">Producto</TableCell>
+                        <TableCell width="25%">Código asociado</TableCell>
+                        <TableCell width="15%" align="center">Acciones</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {items.map((item, index) => (
+                        <TableRow key={`item-${index}`}>
+                          <TableCell>
+                            <TextField
+                              type="number"
+                              size="small"
+                              fullWidth
+                              inputProps={{ min: 0, step: '0.01' }}
+                              value={item.cantidad}
+                              onChange={(event) => handleItemChange(index, 'cantidad', event.target.value)}
+                              error={Boolean(itemErrors[index]?.cantidad)}
+                              helperText={itemErrors[index]?.cantidad || ''}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Autocomplete
+                              options={products}
+                              loading={loadingProducts}
+                              value={item.producto}
+                              onChange={(_, newValue) => handleItemChange(index, 'producto', newValue)}
+                              isOptionEqualToValue={(option, value) => option?._id === value?._id}
+                              getOptionLabel={(option) => option?.descripcion || ''}
+                              renderInput={(params) => (
+                                <TextField
+                                  {...params}
+                                  size="small"
+                                  label="Producto"
+                                  error={Boolean(itemErrors[index]?.producto)}
+                                  helperText={itemErrors[index]?.producto || ''}
+                                  InputProps={{
+                                    ...params.InputProps,
+                                    endAdornment: (
+                                      <>
+                                        {loadingProducts ? <CircularProgress color="inherit" size={18} /> : null}
+                                        {params.InputProps.endAdornment}
+                                      </>
+                                    ),
+                                  }}
+                                />
+                              )}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <TextField
+                              size="small"
+                              fullWidth
+                              value={item.codprod}
+                              onChange={(event) => handleItemChange(index, 'codprod', event.target.value)}
+                              error={Boolean(itemErrors[index]?.codprod)}
+                              helperText={itemErrors[index]?.codprod || ''}
+                            />
+                          </TableCell>
+                          <TableCell align="center">
+                            <IconButton color="error" onClick={() => removeItemRow(index)} disabled={items.length === 1}>
+                              <DeleteIcon />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+
+              <Stack direction="row" justifyContent="flex-end" spacing={2}>
+                <Button
+                  variant="contained"
+                  startIcon={<SaveIcon />}
+                  onClick={handleSave}
+                  disabled={saving || loadingDocumentMeta}
+                >
+                  {saving ? 'Grabando...' : 'Grabar'}
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        )}
+
+        <Snackbar
+          open={snackbar.open}
+          autoHideDuration={6000}
+          onClose={handleSnackbarClose}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        >
+          <Alert onClose={handleSnackbarClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+            {snackbar.message}
+          </Alert>
+        </Snackbar>
+      </Stack>
+    </LocalizationProvider>
+  );
+}

--- a/frontend/src/pages/LoginForm.jsx
+++ b/frontend/src/pages/LoginForm.jsx
@@ -10,35 +10,31 @@ import {
 import { useNavigate } from "react-router-dom";
 import { postLogin } from "../api/rutaUsuarios"; // tu helper original
 // import fondoLogo from "../assets/logo.png"; // 🖼 asegurate de tener esta imagen en src/assets/
+import { useAuth } from "../context/AuthContextState.js";
 
 const LoginForm = () => {
   const navigate = useNavigate();
   const [formValues, setFormValues] = useState({ email: "", password: "" });
   const [user, setUser] = useState({ data: { ok: null }, loading: false });
-  const [isLoggedIn, setIsLoggedIn] = useState(!!localStorage.getItem("token"));
+  const { token, login: authLogin, logout: authLogout } = useAuth();
 
   useEffect(() => {
     if (user.data.ok) {
-      localStorage.setItem("token", user.data.token);
-      localStorage.setItem("id", user.data.usuario._id);
-      localStorage.setItem("usuario", JSON.stringify(user.data.usuario.nombres));
-      setIsLoggedIn(true);
+      authLogin({ token: user.data.token, user: user.data.usuario });
       navigate("/");
     }
-  }, [user, navigate]);
+  }, [authLogin, navigate, user]);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
     if (token) {
       navigate("/");
     }
-  }, [navigate]);
+  }, [navigate, token]);
 
   const logout = useCallback(() => {
-    localStorage.clear();
-    setIsLoggedIn(false);
+    authLogout();
     navigate("/login");
-  }, [navigate]);
+  }, [authLogout, navigate]);
 
   const resetTimer = useCallback(() => {
     clearTimeout(window.inactivityTimeout);
@@ -67,7 +63,7 @@ const LoginForm = () => {
     setFormValues({ email: "", password: "" });
   };
 
-  if (isLoggedIn) {
+  if (token) {
     navigate("/");
     return null;
   }


### PR DESCRIPTION
## Summary
- build a guided documents page that walks through document type selection, dynamic form inputs, and post-save stock updates
- add API helpers plus the MUI date pickers dependency needed for the new workflow
- centralize auth details in a shared context and expose the new Documents option in navigation/routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c975ef13708321ad289018841db0e8