### PR TITLE
Reduce ProductoItem card footprint

### DIFF
--- a/frontend/src/components/ProductoItem.jsx
+++ b/frontend/src/components/ProductoItem.jsx
@@ -26,6 +26,11 @@ export default function ProductoItem({
   const [precio, setPrecio] = useState(null);
   const qtyRef = useRef(null);
   const maxStock = stockDisponible ?? producto.stkactual;
+  const mediaHeight = 112;
+  const iconSize = 48;
+  const contentPadding = 1.5;
+  const contentSpacing = 0.8;
+  const selectMinWidth = 96;
 
   useEffect(() => {
     setListaId(defaultLista);
@@ -70,53 +75,90 @@ export default function ProductoItem({
   }, [focused]);
 
   return (
-    <Card sx={focused ? { outline: '2px solid', outlineColor: 'primary.main' } : undefined}>
+    <Card
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        ...(focused ? { outline: '2px solid', outlineColor: 'primary.main' } : {}),
+      }}
+    >
       {producto.imagen ? (
-        <CardMedia component="img" height="140" image={producto.imagen} alt={producto.descripcion} />
+        <CardMedia
+          component="img"
+          sx={{ height: mediaHeight }}
+          image={producto.imagen}
+          alt={producto.descripcion}
+        />
       ) : (
-        <Box sx={{ height: 140, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: 'grey.200' }}>
-          <ImageIcon sx={{ fontSize: 60, color: 'text.secondary' }} />
+        <Box
+          sx={{
+            height: mediaHeight,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'grey.200',
+          }}
+        >
+          <ImageIcon sx={{ fontSize: iconSize, color: 'text.secondary' }} />
         </Box>
       )}
-      <CardContent>
-        <Typography variant="subtitle1" gutterBottom>{producto.descripcion}</Typography>
+      <CardContent
+        sx={{
+          p: contentPadding,
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: contentSpacing,
+          '&:last-child': { pb: contentPadding },
+        }}
+      >
+        <Typography variant="subtitle1">{producto.descripcion}</Typography>
         <Typography
           variant="body2"
           color={maxStock === 0 ? 'warning.main' : 'text.secondary'}
-          sx={{ mb: 1 }}
         >
           Stock: {maxStock}
         </Typography>
-        <TextField
-          label="Cantidad"
-          type="number"
-          size="small"
-          value={cantidad}
-          onChange={(e) => setCantidad(e.target.value)}
-          inputRef={qtyRef}
-          inputProps={{ min: 1, max: maxStock }}
-          sx={{ mb: 1 }}
-          disabled={maxStock <= 0}
-        />
-        <Select
-          size="small"
-          value={listaId}
-          displayEmpty
-          onChange={(e) => setListaId(e.target.value)}
-          sx={{ mb: 1, minWidth: 120 }}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: contentSpacing,
+            flexGrow: 1,
+          }}
         >
-          <MenuItem value=""><em>Lista</em></MenuItem>
-          {listas.map((l) => (
-            <MenuItem key={l._id} value={l._id}>{l.lista || l.nombre}</MenuItem>
-          ))}
-        </Select>
-        <Typography variant="body2" sx={{ mb: 1 }}>
-          Precio: {precio != null ? `$${precio}` : '-'}
-        </Typography>
+          <TextField
+            label="Cantidad"
+            type="number"
+            size="small"
+            value={cantidad}
+            onChange={(e) => setCantidad(e.target.value)}
+            inputRef={qtyRef}
+            inputProps={{ min: 1, max: maxStock }}
+            disabled={maxStock <= 0}
+          />
+          <Select
+            size="small"
+            value={listaId}
+            displayEmpty
+            onChange={(e) => setListaId(e.target.value)}
+            sx={{ minWidth: selectMinWidth }}
+          >
+            <MenuItem value=""><em>Lista</em></MenuItem>
+            {listas.map((l) => (
+              <MenuItem key={l._id} value={l._id}>{l.lista || l.nombre}</MenuItem>
+            ))}
+          </Select>
+          <Typography variant="body2">
+            Precio: {precio != null ? `$${precio}` : '-'}
+          </Typography>
+        </Box>
         <Button
           variant="contained"
           onClick={handleAdd}
           disabled={!listaId || precio == null || maxStock <= 0}
+          sx={{ alignSelf: 'flex-start' }}
         >
           Agregar
         </Button>


### PR DESCRIPTION
## Summary
- shrink the product card media height, placeholder icon and padding to roughly 80% of their previous size
- reflow the card body with flex layout helpers so controls stay aligned inside the grid at the reduced footprint
- tighten the select width and shared spacing constants for the compact layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f6b68b148323a658cd3a2c6c0f12