### PR TITLE
Add documents nav item in dashboard layout

### DIFF
--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -29,6 +29,7 @@ import SecurityIcon from '@mui/icons-material/Security';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import HistoryIcon from '@mui/icons-material/History';
+import DescriptionIcon from '@mui/icons-material/Description';
 import ThemeSelector from '../components/ThemeSelector.jsx';
 import Footer from '../components/Footer';
 import logo from '../assets/logo.png';
@@ -42,6 +43,7 @@ const navItems = [
   { label: 'Historial', path: '/historial-comandas', icon: <HistoryIcon /> },
   { label: 'Permisos', path: '/permissions', icon: <SecurityIcon /> },
   { label: 'Logística', path: '/logistics',  icon: <LocalShippingIcon /> },
+  { label: 'Documentos', path: '/documents', icon: <DescriptionIcon /> },
 ];
 
 export default function DashboardLayout({ themeName, setThemeName }) {


### PR DESCRIPTION
## Summary
- import the MUI Description icon into the dashboard layout
- add a Documents navigation entry pointing to the /documents route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc5fdc8da8832184e9e97284f4f519