### PR TITLE
Validate manual remito numbers on creation

### DIFF
--- a/backend/server/modelos/documento.js
+++ b/backend/server/modelos/documento.js
@@ -125,6 +125,9 @@ documentoSchema.pre('save', function(next) {
   if (!TIPOS_DOCUMENTO.includes(tipo)) {
     return next(new Error('Tipo de documento inválido'));
   }
+  if (tipo === 'R' && this.isNew && this.NrodeDocumento) {
+    return next();
+  }
   this.NrodeDocumento = `${this.prefijo}${tipo}${padSecuencia(this.secuencia)}`;
   next();
 });


### PR DESCRIPTION
## Summary
- enforce manual remito numbers to be positive, 8-digit padded values on the documents form and include the normalized value when submitting
- validate and normalize incoming remito numbers in the documentos API before persisting
- keep pre-normalized remito numbers when saving documents so the model does not overwrite them

## Testing
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ccc33626808321be2ce23813af5836