### PR TITLE
Validate NR document number handling

### DIFF
--- a/backend/server/modelos/documento.js
+++ b/backend/server/modelos/documento.js
@@ -125,7 +125,7 @@ documentoSchema.pre('save', function(next) {
   if (!TIPOS_DOCUMENTO.includes(tipo)) {
     return next(new Error('Tipo de documento inválido'));
   }
-  if (tipo === 'R' && this.isNew && this.NrodeDocumento) {
+  if (this.isNew && this.NrodeDocumento && (tipo === 'R' || tipo === 'NR')) {
     return next();
   }
   this.NrodeDocumento = `${this.prefijo}${tipo}${padSecuencia(this.secuencia)}`;


### PR DESCRIPTION
## Summary
- require notas de recepción to supply numeroSugerido in the formato NNNNNRNNNNNNNN and forward it unchanged to the modelo
- keep remitos behaviour intact while storing the nota de recepción número when provided
- prevent the documento schema from regenerating NrodeDocumento for new NR registros that already tienen número asignado

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cebae0b4d88321a79f464f0839a574