### PR TITLE
Send suggested number for AJ+ and show backend confirmation

### DIFF
--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -547,6 +547,19 @@ export default function DocumentsPage() {
     if ((baseType === 'R' || baseType === 'NR') && trimmedNumeroDocumento) {
       payload.nroDocumento = trimmedNumeroDocumento;
     }
+    if (selectedType === 'AJ+') {
+      const trimmedNumeroSugerido =
+        numeroSugerido?.toString().trim() || sequenceInfo?.numero?.toString().trim() || '';
+      if (!trimmedNumeroSugerido) {
+        setAlert({
+          open: true,
+          severity: 'warning',
+          message: 'No se pudo determinar el número sugerido para el ajuste.',
+        });
+        return;
+      }
+      payload.nroSugerido = trimmedNumeroSugerido;
+    }
     const responsableId = usuarioResponsable || selectedUserFromStorage || '';
     if (responsableId) {
       payload.usuarioResponsable = responsableId;
@@ -611,12 +624,10 @@ export default function DocumentsPage() {
           message: `Documento registrado pero algunas actualizaciones de stock fallaron: ${formattedStockErrors.join(' | ')}`,
         });
       } else {
-        const manualNumber = baseType === 'R' ? numeroSugerido.trim() : '';
-        const successMessage = sequenceInfo
-          ? `Documento ${sequenceInfo.numero} registrado correctamente.`
-          : manualNumber
-            ? `Documento ${manualNumber} registrado correctamente.`
-            : 'Documento registrado correctamente.';
+        const backendNumber = data?.documento?.NrodeDocumento?.toString().trim();
+        const successMessage = backendNumber
+          ? `Documento ${backendNumber} registrado correctamente.`
+          : 'Documento registrado correctamente.';
         setAlert({ open: true, severity: 'success', message: successMessage });
         resetForm();
       }


### PR DESCRIPTION
## Summary
- reuse the existing suggested number when creating an Ajuste (+) document and include it in the payload as `nroSugerido`
- prevent submissions that lack a trimmed suggested number for AJ+ while keeping existing document number handling
- rely on the backend-confirmed document number when building the success notification

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf119813488321a6a5aa40e692ce77