### PR TITLE
Ensure adjustments send their operation type

### DIFF
--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -541,6 +541,9 @@ export default function DocumentsPage() {
         codprod: item.codprod,
       })),
     };
+    if (baseType === 'AJ') {
+      payload.ajusteOperacion = selectedType === 'AJ+' ? 'increment' : 'decrement';
+    }
     const rawNumeroDocumento =
       baseType === 'NR' && sequenceInfo?.numero ? sequenceInfo.numero : numeroSugerido;
     const trimmedNumeroDocumento = rawNumeroDocumento?.toString().trim();


### PR DESCRIPTION
## Summary
- send the ajusteOperacion flag when creating Ajuste documents so the backend knows whether the adjustment is positive or negative

## Testing
- npm run lint (frontend)
- npm test *(fails: existing backend NR tests return 500 responses even without the frontend change)*

------
https://chatgpt.com/codex/tasks/task_e_68cf512f92e88321825b6ae16361c9a2