### PR TITLE
Send ajusteOperacion for adjustments and cover AJ stock updates

### DIFF
--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -541,6 +541,9 @@ export default function DocumentsPage() {
         codprod: item.codprod,
       })),
     };
+    if (baseType === 'AJ') {
+      payload.ajusteOperacion = ajusteOperacion === 'increment' ? 'increment' : 'decrement';
+    }
     const rawNumeroDocumento =
       baseType === 'NR' && sequenceInfo?.numero ? sequenceInfo.numero : numeroSugerido;
     const trimmedNumeroDocumento = rawNumeroDocumento?.toString().trim();


### PR DESCRIPTION
## Summary
- ensure the frontend sends ajusteOperacion when submitting adjustment documents so AJ(+) requests use the increment flag
- update the documentos route to apply stock increments or decrements for adjustments based on the requested operation
- refactor and extend the documentos test suite to share helpers and add coverage for both AJ(-) and AJ(+) stock updates

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf54bbaecc8321a5a4be6ecb021989