### PR TITLE
Update document title based on selected type

### DIFF
--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -47,6 +47,13 @@ const DOCUMENT_TYPE_OPTIONS = [
   { value: 'AJ-', label: 'Ajuste (-)' },
 ];
 
+const DOCUMENT_TYPE_COLOR_MAP = {
+  R: 'cyan.main',
+  NR: 'cyan.main',
+  'AJ+': 'cyan.main',
+  'AJ-': 'error.main',
+};
+
 const DEFAULT_DATE = new Date().toISOString().split('T')[0];
 
 const normalizePrefijo = (value) => {
@@ -106,12 +113,31 @@ export default function DocumentsPage() {
   const [saving, setSaving] = useState(false);
   const [alert, setAlert] = useState({ open: false, severity: 'success', message: '' });
 
+  const selectedTypeLabel = useMemo(
+    () => DOCUMENT_TYPE_OPTIONS.find((option) => option.value === selectedType)?.label ?? '',
+    [selectedType],
+  );
   const baseType = useMemo(
     () => (selectedType.startsWith('AJ') ? 'AJ' : selectedType),
     [selectedType],
   );
   const previousBaseTypeRef = useRef(baseType);
   const productSearchRequestIdRef = useRef(0);
+
+  const shouldShowTitleSuffix = useMemo(
+    () => Boolean(selectedTypeLabel) && (activeStep === 1 || activeStep === 2),
+    [activeStep, selectedTypeLabel],
+  );
+
+  const titleText = useMemo(
+    () => (shouldShowTitleSuffix ? `Gestión de documentos — ${selectedTypeLabel}` : 'Gestión de documentos'),
+    [selectedTypeLabel, shouldShowTitleSuffix],
+  );
+
+  const titleColor = useMemo(
+    () => (shouldShowTitleSuffix ? DOCUMENT_TYPE_COLOR_MAP[selectedType] : undefined),
+    [selectedType, shouldShowTitleSuffix],
+  );
 
   const isNumeroSugeridoValid = useMemo(() => {
     if (baseType !== 'R') return true;
@@ -945,7 +971,9 @@ export default function DocumentsPage() {
   return (
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
-        <Typography variant="h5">Gestión de documentos</Typography>
+        <Typography variant="h5" sx={titleColor ? { color: titleColor } : undefined}>
+          {titleText}
+        </Typography>
         <Button
           variant="text"
           color="secondary"


### PR DESCRIPTION
## Summary
- derive the selected document type label and reuse it to build the page title suffix
- show the document type in the title for steps 2 and 3 while mapping the heading color to the type tone

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d05ebf1eb08321a5aad60691d374b8