### PR TITLE
Permitir cantidades no nulas en ajustes

### DIFF
--- a/backend/server/modelos/__tests__/documento.test.js
+++ b/backend/server/modelos/__tests__/documento.test.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+
+const Documento = require('../documento');
+
+describe('Modelo Documento - validación de cantidades en ajustes', () => {
+  const buildDocumento = (cantidad) => new Documento({
+    tipo: 'AJ',
+    proveedor: new mongoose.Types.ObjectId(),
+    fechaRemito: new Date('2024-01-01T00:00:00.000Z'),
+    usuario: new mongoose.Types.ObjectId(),
+    items: [
+      {
+        cantidad,
+        producto: new mongoose.Types.ObjectId(),
+        codprod: 'SKU-NEG',
+      },
+    ],
+  });
+
+  test('permite validar un ajuste negativo con cantidad entera distinta de cero', () => {
+    const documento = buildDocumento(-3);
+    const error = documento.validateSync();
+
+    expect(error).toBeUndefined();
+    expect(documento.items[0].cantidad).toBe(-3);
+  });
+
+  test('rechaza cantidades iguales a cero o con decimales', () => {
+    const documentoConCero = buildDocumento(0);
+    const errorCero = documentoConCero.validateSync();
+    expect(errorCero.errors['items.0.cantidad'].message).toBe(
+      'La cantidad debe ser un entero distinto de cero',
+    );
+
+    const documentoConDecimal = buildDocumento(-1.5);
+    const errorDecimal = documentoConDecimal.validateSync();
+    expect(errorDecimal.errors['items.0.cantidad'].message).toBe(
+      'La cantidad debe ser un entero distinto de cero',
+    );
+  });
+});

--- a/backend/server/modelos/documento.js
+++ b/backend/server/modelos/documento.js
@@ -22,8 +22,8 @@ const itemSchema = new Schema({
     type: Number,
     required: [true, 'La cantidad es obligatoria'],
     validate: {
-      validator: (valor) => Number.isInteger(valor) && valor > 0,
-      message: 'La cantidad debe ser un entero positivo',
+      validator: (valor) => Number.isInteger(valor) && valor !== 0,
+      message: 'La cantidad debe ser un entero distinto de cero',
     },
   },
   producto: {


### PR DESCRIPTION
## Summary
- permitir que la validación de items admita enteros distintos de cero en los ajustes y actualizar el mensaje de error
- agregar pruebas unitarias del modelo Documento cubriendo ajustes negativos y la exclusión de ceros o decimales

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d0767c5ca88321ab4845152722b3c9