### PR TITLE
Registrar movimientos de stock para NR y ajustes

### DIFF
--- a/backend/server/modelos/stock.js
+++ b/backend/server/modelos/stock.js
@@ -9,6 +9,12 @@ let stockSchema = new Schema({
     ref: "Producserv",
   },
 
+  documento: {
+    type: Schema.Types.ObjectId,
+    ref: "Documento",
+    index: true,
+  },
+
   nrodecomanda: {
     type: Number,
   },


### PR DESCRIPTION
## Resumen
- agrega una referencia al documento en el esquema de stock para vincular los movimientos creados
- valida que la fecha del documento sea ISO y reutilizable antes de persistir la nota, obteniendo los identificadores de movimiento requeridos
- inserta movimientos de stock para notas de recepción y ajustes positivos/negativos usando insertMany dentro de la transacción, evitando duplicados por documento

## Testing
- no se ejecutaron pruebas (no disponibles)

------
https://chatgpt.com/codex/tasks/task_e_68d40296e72483219cb0d23ef887e95a