### PR TITLE
Extend comanda workflow and logistics dashboards

### DIFF
--- a/backend/server/modelos/comanda.js
+++ b/backend/server/modelos/comanda.js
@@ -2,6 +2,158 @@ const mongoose = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
 let Schema = mongoose.Schema;
 
+// Subdocumento para adjuntos genéricos (fotos, archivos, etc.)
+const archivoSchema = new Schema(
+  {
+    nombre: {
+      type: String,
+      trim: true,
+      maxlength: 200,
+    },
+    url: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+  },
+  { _id: false }
+);
+
+const preparacionSchema = new Schema(
+  {
+    responsable: {
+      type: Schema.Types.ObjectId,
+      ref: 'Usuario',
+    },
+    inicio: {
+      type: Date,
+    },
+    fin: {
+      type: Date,
+    },
+    verificacionBultos: {
+      type: Boolean,
+      default: false,
+    },
+    controlTemperatura: {
+      type: String,
+      trim: true,
+      maxlength: 120,
+    },
+    incidencias: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+    archivos: {
+      type: [archivoSchema],
+      default: [],
+    },
+  },
+  { _id: false, timestamps: { createdAt: 'creadoEn', updatedAt: 'actualizadoEn' } }
+);
+
+const controlCargaSchema = new Schema(
+  {
+    inspector: {
+      type: Schema.Types.ObjectId,
+      ref: 'Usuario',
+    },
+    fechaHora: {
+      type: Date,
+    },
+    checklistDeposito: {
+      type: Boolean,
+      default: false,
+    },
+    selloSeguridad: {
+      type: String,
+      trim: true,
+      maxlength: 80,
+    },
+    anotaciones: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+    adjuntos: {
+      type: [archivoSchema],
+      default: [],
+    },
+  },
+  { _id: false, timestamps: { createdAt: 'creadoEn', updatedAt: 'actualizadoEn' } }
+);
+
+const historialSchema = new Schema(
+  {
+    accion: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 200,
+    },
+    usuario: {
+      type: Schema.Types.ObjectId,
+      ref: 'Usuario',
+    },
+    motivo: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+    fecha: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { _id: false }
+);
+
+const entregaSchema = new Schema(
+  {
+    parada: {
+      type: String,
+      trim: true,
+      maxlength: 200,
+    },
+    estado: {
+      type: String,
+      enum: ['Completada', 'Parcial', 'Rechazada'],
+      default: 'Completada',
+    },
+    fecha: {
+      type: Date,
+      default: Date.now,
+    },
+    motivo: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+    checklistConfirmado: {
+      type: Boolean,
+      default: false,
+    },
+    fotos: {
+      type: [archivoSchema],
+      default: [],
+    },
+    usuario: {
+      type: Schema.Types.ObjectId,
+      ref: 'Usuario',
+    },
+    observaciones: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+    },
+  },
+  {
+    _id: false,
+    timestamps: { createdAt: 'creadoEn', updatedAt: 'actualizadoEn' },
+  }
+);
+
 // Subdocumento para los ítems de la comanda
 const itemSchema = new Schema({
   lista: {
@@ -82,8 +234,47 @@ const comandaSchema = new Schema({
   },
 
   // 💥 Arreglo de ítems de venta
-  items: [itemSchema]
+  items: [itemSchema],
+
+  estadoPreparacion: {
+    type: String,
+    enum: ['A Preparar', 'En Curso', 'Lista para carga'],
+    default: 'A Preparar',
+    index: true,
+  },
+
+  operarioAsignado: {
+    type: Schema.Types.ObjectId,
+    ref: 'Usuario',
+  },
+
+  preparacion: preparacionSchema,
+
+  controlCarga: controlCargaSchema,
+
+  motivoLogistica: {
+    type: String,
+    trim: true,
+    maxlength: 300,
+  },
+
+  usuarioLogistica: {
+    type: Schema.Types.ObjectId,
+    ref: 'Usuario',
+  },
+
+  historial: {
+    type: [historialSchema],
+    default: [],
+  },
+
+  entregas: {
+    type: [entregaSchema],
+    default: [],
+  },
 });
+
+comandaSchema.set('timestamps', true);
 
 comandaSchema.plugin(uniqueValidator, {
   message: "{PATH} debe ser único",

--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -7,6 +7,7 @@ import DocumentsPage from './pages/DocumentsPage.jsx';
 import LoginForm from './pages/LoginForm';
 import PrivateRoute from './components/PrivateRoute';
 import HistorialComandas from './components/HistorialComandas.jsx';
+import LogisticsPage from './pages/LogisticsPage.jsx';
 
 export default function AppRoutes({ themeName, setThemeName }) {
   return (
@@ -25,6 +26,7 @@ export default function AppRoutes({ themeName, setThemeName }) {
         <Route path="/documents" element={<DocumentsPage />} />
         <Route path="comandas" element={<ComandasPage />} />
         <Route path="/historial-comandas" element={<HistorialComandas />} />
+        <Route path="/logistics" element={<LogisticsPage />} />
         {/* Otras rutas aquí */}
       </Route>
     </Routes>

--- a/frontend/src/api/comandas.js
+++ b/frontend/src/api/comandas.js
@@ -1,0 +1,31 @@
+import api from './axios';
+
+export const getComandasAPreparar = async (params = {}) => {
+  const { data } = await api.get('/comandasapreparar', { params });
+  return data?.comandas || [];
+};
+
+export const getComandasActivas = async (params = {}) => {
+  const { data } = await api.get('/comandasactivas', { params });
+  return data?.comandas || [];
+};
+
+export const getComandas = async (params = {}) => {
+  const { data } = await api.get('/comandas', { params });
+  return data?.comandas || [];
+};
+
+export const updateComanda = async (id, payload) => {
+  const { data } = await api.put(`/comandas/${id}`, payload);
+  return data?.comanda;
+};
+
+export const getUsuarios = async () => {
+  const { data } = await api.get('/usuarios');
+  return data?.usuarios || [];
+};
+
+export const getCamiones = async () => {
+  const { data } = await api.get('/camiones');
+  return data?.camiones || [];
+};

--- a/frontend/src/components/logistica/AppCamionReactTable.jsx
+++ b/frontend/src/components/logistica/AppCamionReactTable.jsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import { getComandasActivas } from '../../api/comandas';
+import ModalFormCamion from './ModalFormCamion.jsx';
+
+const hasControlCompletado = (comanda) =>
+  Boolean(comanda?.controlCarga?.checklistDeposito || comanda?.controlCarga?.fechaHora);
+
+const getCamionLabel = (comanda) => comanda?.camion?.camion || comanda?.camion?.patente || 'Sin camión';
+
+export default function AppCamionReactTable({ refreshKey = 0 }) {
+  const [comandas, setComandas] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [selected, setSelected] = useState(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getComandasActivas({ limite: 400 });
+      const filtradas = data.filter((c) => hasControlCompletado(c));
+      setComandas(filtradas);
+      setError('');
+    } catch (err) {
+      console.error('Error obteniendo comandas para camiones', err);
+      setError('No se pudieron cargar las comandas de camiones');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const totalPendientes = useMemo(() => comandas.length, [comandas]);
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Panel de choferes
+        </Typography>
+        <Chip icon={<LocalShippingIcon />} label={`${totalPendientes} pendientes`} color="primary" />
+        <Button variant="outlined" onClick={fetchData}>
+          Actualizar
+        </Button>
+      </Stack>
+      {error && (
+        <Typography color="error" sx={{ mt: 1 }}>
+          {error}
+        </Typography>
+      )}
+      <Box sx={{ position: 'relative', mt: 2 }}>
+        {loading ? (
+          <Stack alignItems="center" sx={{ py: 4 }}>
+            <CircularProgress />
+          </Stack>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>N.º</TableCell>
+                <TableCell>Cliente</TableCell>
+                <TableCell>Camión</TableCell>
+                <TableCell>Checklist</TableCell>
+                <TableCell align="right">Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {comandas.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} align="center">
+                    No hay comandas pendientes de reparto.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                comandas.map((comanda) => (
+                  <TableRow key={comanda._id} hover>
+                    <TableCell>{comanda.nrodecomanda}</TableCell>
+                    <TableCell>{comanda.codcli?.razonsocial || '—'}</TableCell>
+                    <TableCell>{getCamionLabel(comanda)}</TableCell>
+                    <TableCell>
+                      {hasControlCompletado(comanda) ? (
+                        <Chip size="small" color="success" label="Checklist completo" />
+                      ) : (
+                        <Chip size="small" color="warning" label="Pendiente" />
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      <Button size="small" onClick={() => setSelected(comanda)}>
+                        Registrar entrega
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </Box>
+      <ModalFormCamion
+        open={Boolean(selected)}
+        comanda={selected}
+        onClose={() => setSelected(null)}
+        onSaved={() => {
+          setSelected(null);
+          fetchData();
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/logistica/AppGestionReactTable.jsx
+++ b/frontend/src/components/logistica/AppGestionReactTable.jsx
@@ -1,0 +1,287 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import dayjs from 'dayjs';
+import { getComandas } from '../../api/comandas';
+
+const formatDate = (value) => (value ? dayjs(value).format('DD/MM/YYYY HH:mm') : '—');
+
+const calcularMetrics = (comandas) => {
+  let totalPrep = 0;
+  let countPrep = 0;
+  let totalDemora = 0;
+  let countDemora = 0;
+  let totalEntregas = 0;
+  let entregasParciales = 0;
+
+  comandas.forEach((comanda) => {
+    if (comanda.preparacion?.inicio && comanda.preparacion?.fin) {
+      const diff = dayjs(comanda.preparacion.fin).diff(dayjs(comanda.preparacion.inicio), 'minute');
+      if (!Number.isNaN(diff)) {
+        totalPrep += diff;
+        countPrep += 1;
+      }
+    }
+    if (comanda.preparacion?.fin && comanda.controlCarga?.fechaHora) {
+      const diff = dayjs(comanda.controlCarga.fechaHora).diff(dayjs(comanda.preparacion.fin), 'minute');
+      if (!Number.isNaN(diff)) {
+        totalDemora += diff;
+        countDemora += 1;
+      }
+    }
+    if (Array.isArray(comanda.entregas)) {
+      comanda.entregas.forEach((entrega) => {
+        totalEntregas += 1;
+        if (['Parcial', 'Rechazada'].includes(entrega.estado)) entregasParciales += 1;
+      });
+    }
+  });
+
+  return {
+    tiempoPromedioPreparacion: countPrep ? totalPrep / countPrep : 0,
+    demoraPromedioDespacho: countDemora ? totalDemora / countDemora : 0,
+    porcentajeEntregasParciales: totalEntregas ? (entregasParciales / totalEntregas) * 100 : 0,
+  };
+};
+
+export default function AppGestionReactTable({ refreshKey = 0, onMetricsCalculated }) {
+  const [comandas, setComandas] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [estado, setEstado] = useState('Todos');
+  const [operario, setOperario] = useState('Todos');
+  const [camion, setCamion] = useState('Todos');
+  const [fechaDesde, setFechaDesde] = useState('');
+  const [fechaHasta, setFechaHasta] = useState('');
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getComandas({ limite: 500 });
+      setComandas(data);
+      setError('');
+      const metrics = calcularMetrics(data);
+      if (typeof onMetricsCalculated === 'function') onMetricsCalculated(metrics);
+    } catch (err) {
+      console.error('Error obteniendo gestión de comandas', err);
+      setError('No se pudieron cargar los datos de gestión');
+    } finally {
+      setLoading(false);
+    }
+  }, [onMetricsCalculated]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const estados = useMemo(() => ['Todos', ...new Set(comandas.map((c) => c.estadoPreparacion || 'A Preparar'))], [comandas]);
+  const operarios = useMemo(() => {
+    const set = new Set();
+    comandas.forEach((c) => {
+      if (c.operarioAsignado?.nombres || c.operarioAsignado?.apellidos) {
+        set.add(`${c.operarioAsignado.nombres || ''} ${c.operarioAsignado.apellidos || ''}`.trim());
+      }
+    });
+    return ['Todos', ...Array.from(set)];
+  }, [comandas]);
+  const camiones = useMemo(() => {
+    const set = new Set();
+    comandas.forEach((c) => {
+      if (c.camion?.camion) set.add(c.camion.camion);
+    });
+    return ['Todos', ...Array.from(set)];
+  }, [comandas]);
+
+  const filtradas = useMemo(() => {
+    return comandas.filter((comanda) => {
+      if (estado !== 'Todos' && (comanda.estadoPreparacion || 'A Preparar') !== estado) return false;
+      if (
+        operario !== 'Todos' &&
+        `${comanda.operarioAsignado?.nombres || ''} ${comanda.operarioAsignado?.apellidos || ''}`.trim() !== operario
+      )
+        return false;
+      if (camion !== 'Todos' && comanda.camion?.camion !== camion) return false;
+      if (fechaDesde && dayjs(comanda.fecha).isBefore(dayjs(fechaDesde))) return false;
+      if (fechaHasta && dayjs(comanda.fecha).isAfter(dayjs(fechaHasta).endOf('day'))) return false;
+      return true;
+    });
+  }, [comandas, estado, operario, camion, fechaDesde, fechaHasta]);
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Gestión y seguimiento
+        </Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+          <FormControl size="small" sx={{ minWidth: 150 }}>
+            <InputLabel id="estado-label">Estado</InputLabel>
+            <Select labelId="estado-label" label="Estado" value={estado} onChange={(event) => setEstado(event.target.value)}>
+              {estados.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small" sx={{ minWidth: 150 }}>
+            <InputLabel id="operario-label">Operario</InputLabel>
+            <Select labelId="operario-label" label="Operario" value={operario} onChange={(event) => setOperario(event.target.value)}>
+              {operarios.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small" sx={{ minWidth: 150 }}>
+            <InputLabel id="camion-label">Camión</InputLabel>
+            <Select labelId="camion-label" label="Camión" value={camion} onChange={(event) => setCamion(event.target.value)}>
+              {camiones.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Desde"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={fechaDesde}
+            onChange={(event) => setFechaDesde(event.target.value)}
+          />
+          <TextField
+            label="Hasta"
+            type="date"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            value={fechaHasta}
+            onChange={(event) => setFechaHasta(event.target.value)}
+          />
+        </Stack>
+      </Stack>
+      {error && (
+        <Typography color="error" sx={{ mt: 1 }}>
+          {error}
+        </Typography>
+      )}
+      <Box sx={{ position: 'relative', mt: 2 }}>
+        {loading ? (
+          <Stack alignItems="center" sx={{ py: 4 }}>
+            <CircularProgress />
+          </Stack>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>N.º</TableCell>
+                <TableCell>Cliente</TableCell>
+                <TableCell>Estado</TableCell>
+                <TableCell>Operario</TableCell>
+                <TableCell>Camión</TableCell>
+                <TableCell>Seguimiento</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filtradas.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    Sin resultados
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filtradas.map((comanda) => (
+                  <TableRow key={comanda._id}>
+                    <TableCell>{comanda.nrodecomanda}</TableCell>
+                    <TableCell>{comanda.codcli?.razonsocial || '—'}</TableCell>
+                    <TableCell>
+                      <Chip size="small" label={comanda.estadoPreparacion || 'A Preparar'} />
+                    </TableCell>
+                    <TableCell>
+                      {comanda.operarioAsignado?.nombres || comanda.operarioAsignado?.apellidos
+                        ? `${comanda.operarioAsignado.nombres || ''} ${comanda.operarioAsignado.apellidos || ''}`.trim()
+                        : '—'}
+                    </TableCell>
+                    <TableCell>{comanda.camion?.camion || '—'}</TableCell>
+                    <TableCell>
+                      <Accordion sx={{ boxShadow: 'none', bgcolor: 'transparent' }}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                          <Typography variant="body2">Ver historial</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                          <Stack spacing={1}>
+                            <Typography variant="subtitle2">Preparación</Typography>
+                            <Typography variant="body2">
+                              Responsable:{' '}
+                              {comanda.preparacion?.responsable?.nombres || comanda.preparacion?.responsable?.apellidos
+                                ? `${comanda.preparacion.responsable.nombres || ''} ${comanda.preparacion.responsable.apellidos || ''}`.trim()
+                                : '—'}
+                            </Typography>
+                            <Typography variant="body2">Inicio: {formatDate(comanda.preparacion?.inicio)}</Typography>
+                            <Typography variant="body2">Fin: {formatDate(comanda.preparacion?.fin)}</Typography>
+                            <Typography variant="subtitle2">Control de carga</Typography>
+                            <Typography variant="body2">
+                              Inspector:{' '}
+                              {comanda.controlCarga?.inspector?.nombres || comanda.controlCarga?.inspector?.apellidos
+                                ? `${comanda.controlCarga.inspector.nombres || ''} ${comanda.controlCarga.inspector.apellidos || ''}`.trim()
+                                : '—'}
+                            </Typography>
+                            <Typography variant="body2">
+                              Checklist depósito: {comanda.controlCarga?.checklistDeposito ? 'Sí' : 'No'}
+                            </Typography>
+                            <Typography variant="body2">Fecha control: {formatDate(comanda.controlCarga?.fechaHora)}</Typography>
+                            <Typography variant="subtitle2">Historial de eventos</Typography>
+                            <Stack spacing={0.5}>
+                              {(comanda.historial || []).map((evento, index) => (
+                                <Typography key={`${comanda._id}-hist-${index}`} variant="body2">
+                                  {formatDate(evento.fecha)} — {evento.accion}
+                                </Typography>
+                              ))}
+                            </Stack>
+                            {Array.isArray(comanda.entregas) && comanda.entregas.length > 0 && (
+                              <>
+                                <Typography variant="subtitle2">Entregas</Typography>
+                                <Stack spacing={0.5}>
+                                  {comanda.entregas.map((entrega, index) => (
+                                    <Typography key={`${comanda._id}-ent-${index}`} variant="body2">
+                                      {formatDate(entrega.fecha)} — {entrega.estado} — {entrega.motivo || 'Sin motivo'}
+                                    </Typography>
+                                  ))}
+                                </Stack>
+                              </>
+                            )}
+                          </Stack>
+                        </AccordionDetails>
+                      </Accordion>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/logistica/AppOrdenAPrepararReactTable.jsx
+++ b/frontend/src/components/logistica/AppOrdenAPrepararReactTable.jsx
@@ -1,0 +1,297 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+  Tooltip,
+  IconButton,
+} from '@mui/material';
+import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import ChecklistIcon from '@mui/icons-material/Checklist';
+import { getComandasAPreparar, updateComanda } from '../../api/comandas';
+import PreparacionDrawer from './PreparacionDrawer.jsx';
+
+const DEFAULT_INTERVAL = 60000;
+const INTERVAL_OPTIONS = [30000, 60000, 90000, 120000];
+
+const getClienteNombre = (comanda) => comanda?.codcli?.razonsocial || '—';
+const getRutaNombre = (comanda) =>
+  comanda?.codcli?.ruta?.nombre || comanda?.codcli?.ruta?.descripcion || 'Sin ruta';
+
+export default function AppOrdenAPrepararReactTable({ onDataChange, onManualRefresh }) {
+  const [comandas, setComandas] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [intervalMs, setIntervalMs] = useState(DEFAULT_INTERVAL);
+  const [paused, setPaused] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [selectedRuta, setSelectedRuta] = useState('');
+  const [selectedComanda, setSelectedComanda] = useState(null);
+
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+
+  const fetchData = useCallback(
+    async (showLoader = false) => {
+      try {
+        if (showLoader) setLoading(true);
+        const data = await getComandasAPreparar();
+        setComandas(data);
+        setLastUpdated(Date.now());
+        setError('');
+        if (typeof onDataChange === 'function') onDataChange(data);
+        if (typeof onManualRefresh === 'function') onManualRefresh();
+      } catch (err) {
+        console.error('Error obteniendo comandas a preparar', err);
+        setError('No se pudieron cargar las comandas.');
+      } finally {
+        setLoading(false);
+        setInitialLoading(false);
+      }
+    },
+    [onDataChange, onManualRefresh]
+  );
+
+  useEffect(() => {
+    fetchData(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (paused) return undefined;
+    const timer = setInterval(() => {
+      fetchData(false);
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [fetchData, intervalMs, paused]);
+
+  const handleTogglePause = () => setPaused((prev) => !prev);
+  const handleIntervalChange = (event) => setIntervalMs(event.target.value);
+  const handleRefresh = () => fetchData(true);
+
+  const rutasDisponibles = useMemo(() => {
+    const rutas = new Set();
+    comandas.forEach((c) => {
+      const ruta = getRutaNombre(c);
+      if (ruta) rutas.add(ruta);
+    });
+    return ['Todas', ...Array.from(rutas)];
+  }, [comandas]);
+
+  const filtradas = useMemo(() => {
+    if (!selectedRuta || selectedRuta === 'Todas') return comandas;
+    return comandas.filter((c) => getRutaNombre(c) === selectedRuta);
+  }, [comandas, selectedRuta]);
+
+  const secondsAgo = useMemo(() => {
+    if (!lastUpdated) return '—';
+    const diff = Math.floor((Date.now() - lastUpdated) / 1000);
+    if (diff < 60) return `${diff} segundo${diff === 1 ? '' : 's'}`;
+    const minutes = Math.floor(diff / 60);
+    return `${minutes} minuto${minutes === 1 ? '' : 's'}`;
+  }, [lastUpdated]);
+
+  const handleTakeComanda = async (comanda) => {
+    if (!currentUserId) {
+      alert('No se encontró el usuario en sesión.');
+      return;
+    }
+    try {
+      await updateComanda(comanda._id, {
+        operarioAsignado: currentUserId,
+        preparacion: {
+          responsable: currentUserId,
+          inicio: comanda?.preparacion?.inicio || new Date().toISOString(),
+        },
+        estadoPreparacion: 'En Curso',
+        motivoHistorial: 'Toma de comanda por operario',
+      });
+      fetchData(true);
+    } catch (err) {
+      console.error('Error tomando comanda', err);
+      alert('No se pudo tomar la comanda.');
+    }
+  };
+
+  const handleOpenChecklist = (comanda) => setSelectedComanda(comanda);
+  const handleCloseChecklist = () => setSelectedComanda(null);
+  const handleChecklistSaved = () => {
+    handleCloseChecklist();
+    fetchData(true);
+  };
+
+  return (
+    <Box sx={{ p: 2, bgcolor: 'background.paper', borderRadius: 2, boxShadow: 1 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Comandas a preparar
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Tooltip title={paused ? 'Reanudar sincronización' : 'Pausar sincronización'}>
+            <IconButton color={paused ? 'primary' : 'default'} onClick={handleTogglePause}>
+              {paused ? <PlayCircleOutlineIcon /> : <PauseCircleOutlineIcon />}
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Actualizar ahora">
+            <IconButton onClick={handleRefresh}>
+              <RefreshIcon />
+            </IconButton>
+          </Tooltip>
+          <FormControl size="small">
+            <InputLabel id="interval-label">Intervalo</InputLabel>
+            <Select
+              labelId="interval-label"
+              value={intervalMs}
+              label="Intervalo"
+              onChange={handleIntervalChange}
+            >
+              {INTERVAL_OPTIONS.map((ms) => (
+                <MenuItem key={ms} value={ms}>
+                  {ms / 1000} s
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Typography variant="body2" color="text.secondary">
+            Actualizado hace {secondsAgo}
+          </Typography>
+        </Stack>
+      </Stack>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mt: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="ruta-filter-label">Ruta/Zona</InputLabel>
+          <Select
+            labelId="ruta-filter-label"
+            value={selectedRuta || 'Todas'}
+            label="Ruta/Zona"
+            onChange={(event) => setSelectedRuta(event.target.value)}
+          >
+            {rutasDisponibles.map((ruta) => (
+              <MenuItem key={ruta} value={ruta}>
+                {ruta}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {error && (
+          <Chip color="error" label={error} />
+        )}
+      </Stack>
+
+      <Box sx={{ position: 'relative', mt: 2 }}>
+        {initialLoading ? (
+          <Stack alignItems="center" sx={{ py: 4 }}>
+            <CircularProgress />
+          </Stack>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>N.º</TableCell>
+                <TableCell>Cliente</TableCell>
+                <TableCell>Ruta/Zona</TableCell>
+                <TableCell>Asignado</TableCell>
+                <TableCell>Estado preparación</TableCell>
+                <TableCell align="right">Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filtradas.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    No hay comandas pendientes.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filtradas.map((comanda) => {
+                  const asignado =
+                    comanda?.operarioAsignado?.nombres || comanda?.operarioAsignado?.apellidos
+                      ? `${comanda.operarioAsignado.nombres || ''} ${comanda.operarioAsignado.apellidos || ''}`.trim()
+                      : comanda?.operarioAsignado
+                      ? 'Asignado'
+                      : 'Sin asignar';
+                  return (
+                    <TableRow key={comanda._id} hover>
+                      <TableCell>{comanda.nrodecomanda}</TableCell>
+                      <TableCell>{getClienteNombre(comanda)}</TableCell>
+                      <TableCell>{getRutaNombre(comanda)}</TableCell>
+                      <TableCell>
+                        {asignado === 'Sin asignar' ? (
+                          <Chip label="Sin asignar" color="warning" size="small" />
+                        ) : (
+                          <Chip label={asignado} color="success" size="small" />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Chip label={comanda.estadoPreparacion || 'A Preparar'} size="small" />
+                      </TableCell>
+                      <TableCell align="right">
+                        <Stack direction="row" spacing={1} justifyContent="flex-end">
+                          <Tooltip title="Tomar comanda">
+                            <span>
+                              <Button
+                                size="small"
+                                color="primary"
+                                startIcon={<AssignmentTurnedInIcon />}
+                                onClick={() => handleTakeComanda(comanda)}
+                                disabled={loading}
+                              >
+                                Tomar
+                              </Button>
+                            </span>
+                          </Tooltip>
+                          <Tooltip title="Checklist de preparación">
+                            <IconButton size="small" onClick={() => handleOpenChecklist(comanda)}>
+                              <ChecklistIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        )}
+        {loading && !initialLoading && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              bgcolor: 'rgba(255,255,255,0.65)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <CircularProgress size={28} />
+          </Box>
+        )}
+      </Box>
+
+      <PreparacionDrawer
+        open={Boolean(selectedComanda)}
+        comanda={selectedComanda}
+        onClose={handleCloseChecklist}
+        onSaved={handleChecklistSaved}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/logistica/ControlCargaModal.jsx
+++ b/frontend/src/components/logistica/ControlCargaModal.jsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import dayjs from 'dayjs';
+import { getUsuarios, updateComanda } from '../../api/comandas';
+
+const formatDateTime = (value) => {
+  if (!value) return '';
+  return dayjs(value).format('YYYY-MM-DDTHH:mm');
+};
+
+const parseDateTime = (value) => {
+  if (!value) return undefined;
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.toISOString() : undefined;
+};
+
+export default function ControlCargaModal({ open, comanda, onClose, onSaved }) {
+  const [usuarios, setUsuarios] = useState([]);
+  const [form, setForm] = useState({
+    inspector: '',
+    fechaHora: '',
+    checklistDeposito: false,
+    selloSeguridad: '',
+    anotaciones: '',
+    adjuntos: [],
+  });
+  const [nuevoAdjunto, setNuevoAdjunto] = useState({ nombre: '', url: '' });
+  const [saving, setSaving] = useState(false);
+
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const fetchUsuarios = async () => {
+      try {
+        const data = await getUsuarios();
+        setUsuarios(data);
+      } catch (err) {
+        console.error('Error cargando usuarios', err);
+      }
+    };
+    fetchUsuarios();
+  }, [open]);
+
+  useEffect(() => {
+    if (!comanda) return;
+    const control = comanda.controlCarga || {};
+    setForm({
+      inspector: control.inspector?._id || control.inspector || currentUserId || '',
+      fechaHora: formatDateTime(control.fechaHora) || formatDateTime(new Date()),
+      checklistDeposito: Boolean(control.checklistDeposito),
+      selloSeguridad: control.selloSeguridad || '',
+      anotaciones: control.anotaciones || '',
+      adjuntos: Array.isArray(control.adjuntos) ? control.adjuntos : [],
+    });
+  }, [comanda, currentUserId]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCheckbox = (event) => {
+    const { name, checked } = event.target;
+    setForm((prev) => ({ ...prev, [name]: checked }));
+  };
+
+  const handleAgregarAdjunto = () => {
+    if (!nuevoAdjunto.nombre || !nuevoAdjunto.url) return;
+    setForm((prev) => ({ ...prev, adjuntos: [...prev.adjuntos, { ...nuevoAdjunto }] }));
+    setNuevoAdjunto({ nombre: '', url: '' });
+  };
+
+  const handleRemoveAdjunto = (index) => {
+    setForm((prev) => ({
+      ...prev,
+      adjuntos: prev.adjuntos.filter((_, idx) => idx !== index),
+    }));
+  };
+
+  const handleSave = async () => {
+    if (!comanda) return;
+    if (!form.inspector) {
+      alert('Seleccioná inspector de carga');
+      return;
+    }
+    try {
+      setSaving(true);
+      await updateComanda(comanda._id, {
+        controlCarga: {
+          inspector: form.inspector,
+          fechaHora: parseDateTime(form.fechaHora) || new Date().toISOString(),
+          checklistDeposito: form.checklistDeposito,
+          selloSeguridad: form.selloSeguridad || undefined,
+          anotaciones: form.anotaciones || undefined,
+          adjuntos: form.adjuntos,
+        },
+        motivoHistorial: 'Control de carga registrado',
+      });
+      if (typeof onSaved === 'function') onSaved();
+    } catch (err) {
+      console.error('Error registrando control de carga', err);
+      alert('No se pudo registrar el control de carga.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        Control de carga — Comanda #{comanda?.nrodecomanda}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="inspector-label">Inspector de carga</InputLabel>
+            <Select
+              labelId="inspector-label"
+              name="inspector"
+              label="Inspector de carga"
+              value={form.inspector}
+              onChange={handleChange}
+            >
+              {usuarios.map((user) => (
+                <MenuItem key={user._id} value={user._id}>
+                  {user.nombres} {user.apellidos}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Fecha y hora"
+            type="datetime-local"
+            name="fechaHora"
+            value={form.fechaHora}
+            onChange={handleChange}
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={form.checklistDeposito}
+                onChange={handleCheckbox}
+                name="checklistDeposito"
+              />
+            }
+            label="Checklist de depósito confirmado"
+          />
+          <TextField
+            label="Sello de seguridad"
+            name="selloSeguridad"
+            value={form.selloSeguridad}
+            onChange={handleChange}
+            fullWidth
+          />
+          <TextField
+            label="Anotaciones"
+            name="anotaciones"
+            value={form.anotaciones}
+            onChange={handleChange}
+            fullWidth
+            multiline
+            minRows={2}
+          />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+            <TextField
+              label="Nombre adjunto"
+              value={nuevoAdjunto.nombre}
+              onChange={(event) => setNuevoAdjunto((prev) => ({ ...prev, nombre: event.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="URL adjunto"
+              value={nuevoAdjunto.url}
+              onChange={(event) => setNuevoAdjunto((prev) => ({ ...prev, url: event.target.value }))}
+              size="small"
+              fullWidth
+            />
+            <Button variant="outlined" size="small" onClick={handleAgregarAdjunto}>
+              Agregar
+            </Button>
+          </Stack>
+          <List dense>
+            {form.adjuntos.map((adjunto, index) => (
+              <ListItem key={`${adjunto.url}-${index}`} secondaryAction={
+                <IconButton edge="end" onClick={() => handleRemoveAdjunto(index)}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              }>
+                <ListItemText primary={adjunto.nombre} secondary={adjunto.url} />
+              </ListItem>
+            ))}
+            {form.adjuntos.length === 0 && (
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                Sin adjuntos cargados
+              </Typography>
+            )}
+          </List>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cerrar</Button>
+        <Button onClick={handleSave} variant="contained" disabled={saving}>
+          Guardar control de carga
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/logistica/KanbanPreparacion.jsx
+++ b/frontend/src/components/logistica/KanbanPreparacion.jsx
@@ -1,0 +1,349 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import DoneAllIcon from '@mui/icons-material/DoneAll';
+import { getComandasActivas, updateComanda } from '../../api/comandas';
+import ControlCargaModal from './ControlCargaModal.jsx';
+
+const STATES = ['A Preparar', 'En Curso', 'Lista para carga'];
+const TRANSITIONS = {
+  'A Preparar': 'En Curso',
+  'En Curso': 'Lista para carga',
+  'Lista para carga': null,
+};
+
+const getCliente = (comanda) => comanda?.codcli?.razonsocial || '—';
+const getRuta = (comanda) =>
+  comanda?.codcli?.ruta?.nombre || comanda?.codcli?.ruta?.descripcion || 'Sin ruta';
+
+export default function KanbanPreparacion({ refreshKey = 0 }) {
+  const [comandas, setComandas] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [selectedRuta, setSelectedRuta] = useState('Todas');
+  const [selectedOperario, setSelectedOperario] = useState('Todos');
+  const [search, setSearch] = useState('');
+  const [controlComanda, setControlComanda] = useState(null);
+  const [draggedId, setDraggedId] = useState(null);
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getComandasActivas({ limite: 400 });
+      setComandas(data);
+      setError('');
+    } catch (err) {
+      console.error('Error obteniendo comandas activas', err);
+      setError('No se pudieron cargar las comandas activas');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const rutas = useMemo(() => {
+    const set = new Set();
+    comandas.forEach((c) => set.add(getRuta(c)));
+    return ['Todas', ...Array.from(set)];
+  }, [comandas]);
+
+  const operarios = useMemo(() => {
+    const set = new Set();
+    comandas.forEach((c) => {
+      if (c.operarioAsignado?.nombres || c.operarioAsignado?.apellidos) {
+        set.add(`${c.operarioAsignado.nombres || ''} ${c.operarioAsignado.apellidos || ''}`.trim());
+      }
+    });
+    return ['Todos', ...Array.from(set)];
+  }, [comandas]);
+
+  const filtradas = useMemo(() => {
+    return comandas.filter((comanda) => {
+      if (selectedRuta !== 'Todas' && getRuta(comanda) !== selectedRuta) return false;
+      if (
+        selectedOperario !== 'Todos' &&
+        `${comanda.operarioAsignado?.nombres || ''} ${comanda.operarioAsignado?.apellidos || ''}`.trim() !== selectedOperario
+      )
+        return false;
+      if (search) {
+        const texto = `${getCliente(comanda)} ${comanda.nrodecomanda}`.toLowerCase();
+        if (!texto.includes(search.toLowerCase())) return false;
+      }
+      return true;
+    });
+  }, [comandas, selectedRuta, selectedOperario, search]);
+
+  const columns = useMemo(() => {
+    const map = Object.fromEntries(STATES.map((state) => [state, []]));
+    filtradas.forEach((comanda) => {
+      const estado = comanda.estadoPreparacion || 'A Preparar';
+      map[estado] = map[estado] || [];
+      map[estado].push(comanda);
+    });
+    return map;
+  }, [filtradas]);
+
+  const handleTakeComanda = async (comanda) => {
+    if (!currentUserId) {
+      alert('No se encontró usuario logueado.');
+      return;
+    }
+    try {
+      await updateComanda(comanda._id, {
+        operarioAsignado: currentUserId,
+        preparacion: {
+          responsable: currentUserId,
+          inicio: comanda.preparacion?.inicio || new Date().toISOString(),
+        },
+        estadoPreparacion: 'En Curso',
+        motivoHistorial: 'Asignación desde tablero Kanban',
+      });
+      fetchData();
+    } catch (err) {
+      console.error('Error asignando comanda', err);
+      alert('No se pudo asignar la comanda.');
+    }
+  };
+
+  const handleDrop = async (comanda, destino) => {
+    const origen = comanda.estadoPreparacion || 'A Preparar';
+    if (destino === origen) return;
+    if (TRANSITIONS[origen] !== destino) {
+      alert('Sólo se puede avanzar una etapa a la vez.');
+      return;
+    }
+    if (!comanda) return;
+    if (destino === 'Lista para carga') {
+      const asignadoId = comanda.operarioAsignado?._id || comanda.operarioAsignado;
+      if (!asignadoId || String(asignadoId) !== String(currentUserId)) {
+        alert('Sólo el operario asignado puede finalizar la preparación.');
+        return;
+      }
+    }
+    try {
+      const payload = {
+        estadoPreparacion: destino,
+        motivoHistorial: `Movimiento Kanban ${origen} → ${destino}`,
+      };
+      if (destino === 'En Curso' && !comanda.preparacion?.inicio) {
+        payload.preparacion = { inicio: new Date().toISOString() };
+      }
+      if (destino === 'Lista para carga') {
+        payload.preparacion = {
+          ...(payload.preparacion || {}),
+          fin: new Date().toISOString(),
+        };
+      }
+      await updateComanda(comanda._id, payload);
+      fetchData();
+    } catch (err) {
+      console.error('Error moviendo tarjeta', err);
+      alert('No se pudo actualizar la comanda.');
+    }
+  };
+
+  const openControlCarga = (comanda) => {
+    if (comanda.estadoPreparacion !== 'Lista para carga') {
+      alert('El control de carga solo está disponible cuando la comanda está lista para carga.');
+      return;
+    }
+    setControlComanda(comanda);
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Tablero de depósito
+        </Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="kanban-ruta">Ruta/Zona</InputLabel>
+            <Select
+              labelId="kanban-ruta"
+              label="Ruta/Zona"
+              value={selectedRuta}
+              onChange={(event) => setSelectedRuta(event.target.value)}
+            >
+              {rutas.map((ruta) => (
+                <MenuItem key={ruta} value={ruta}>
+                  {ruta}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="kanban-operario">Operario</InputLabel>
+            <Select
+              labelId="kanban-operario"
+              label="Operario"
+              value={selectedOperario}
+              onChange={(event) => setSelectedOperario(event.target.value)}
+            >
+              {operarios.map((op) => (
+                <MenuItem key={op} value={op}>
+                  {op}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Buscar"
+            size="small"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <Button variant="outlined" onClick={fetchData}>
+            Actualizar
+          </Button>
+        </Stack>
+      </Stack>
+
+      {error && (
+        <Typography color="error" sx={{ mt: 1 }}>
+          {error}
+        </Typography>
+      )}
+
+      <Box sx={{ mt: 2, position: 'relative' }}>
+        {loading && (
+          <Stack alignItems="center" sx={{ py: 6 }}>
+            <CircularProgress />
+          </Stack>
+        )}
+        {!loading && (
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+            {STATES.map((estado) => (
+              <Box
+                key={estado}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  const id = event.dataTransfer.getData('text/plain') || draggedId;
+                  const comanda = filtradas.find((c) => c._id === id);
+                  if (comanda) handleDrop(comanda, estado);
+                  setDraggedId(null);
+                }}
+                sx={{
+                  flex: 1,
+                  minHeight: 260,
+                  bgcolor: 'background.paper',
+                  borderRadius: 2,
+                  p: 1.5,
+                  boxShadow: 1,
+                }}
+              >
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                  <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+                    {estado}
+                  </Typography>
+                  <Chip label={columns[estado]?.length || 0} size="small" />
+                </Stack>
+                <Stack spacing={1}>
+                  {columns[estado]?.map((comanda) => {
+                    const assigned =
+                      comanda.operarioAsignado?.nombres || comanda.operarioAsignado?.apellidos
+                        ? `${comanda.operarioAsignado.nombres || ''} ${comanda.operarioAsignado.apellidos || ''}`.trim()
+                        : comanda.operarioAsignado
+                        ? 'Asignado'
+                        : 'Sin asignar';
+                    return (
+                      <Card
+                        key={comanda._id}
+                        draggable
+                        onDragStart={(event) => {
+                          setDraggedId(comanda._id);
+                          event.dataTransfer.setData('text/plain', comanda._id);
+                        }}
+                        onDragEnd={() => setDraggedId(null)}
+                        sx={{ border: '1px solid transparent', '&:active': { borderColor: 'primary.main' } }}
+                      >
+                        <CardHeader
+                          title={`#${comanda.nrodecomanda} — ${getCliente(comanda)}`}
+                          subheader={getRuta(comanda)}
+                          sx={{ pb: 1 }}
+                        />
+                        <CardContent sx={{ pt: 0 }}>
+                          <Stack spacing={1}>
+                            <Typography variant="body2" color="text.secondary">
+                              Bultos: {Array.isArray(comanda.items) ? comanda.items.reduce((sum, item) => sum + (item.cantidad || 0), 0) : 0}
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              Operario: {assigned}
+                            </Typography>
+                            <Stack direction="row" spacing={1}>
+                              {comanda.preparacion?.inicio && (
+                                <Chip label={`Inicio ${new Date(comanda.preparacion.inicio).toLocaleTimeString()}`} size="small" />
+                              )}
+                              {comanda.preparacion?.fin && (
+                                <Chip label={`Fin ${new Date(comanda.preparacion.fin).toLocaleTimeString()}`} size="small" color="success" />
+                              )}
+                            </Stack>
+                            <Stack direction="row" spacing={1}>
+                              {!comanda.operarioAsignado && (
+                                <Button size="small" startIcon={<PlayArrowIcon />} onClick={() => handleTakeComanda(comanda)}>
+                                  Tomar
+                                </Button>
+                              )}
+                              {estado === 'Lista para carga' && (
+                                <Button
+                                  size="small"
+                                  startIcon={<LocalShippingIcon />}
+                                  onClick={() => openControlCarga(comanda)}
+                                >
+                                  Control carga
+                                </Button>
+                              )}
+                              {estado === 'Lista para carga' && comanda.controlCarga?.checklistDeposito && (
+                                <Chip size="small" color="success" icon={<DoneAllIcon />} label="Control ok" />
+                              )}
+                            </Stack>
+                          </Stack>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                  {(!columns[estado] || columns[estado].length === 0) && (
+                    <Typography variant="caption" color="text.secondary">
+                      No hay comandas en este estado.
+                    </Typography>
+                  )}
+                </Stack>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      <ControlCargaModal
+        open={Boolean(controlComanda)}
+        comanda={controlComanda}
+        onClose={() => setControlComanda(null)}
+        onSaved={() => {
+          setControlComanda(null);
+          fetchData();
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/logistica/ModalFormAsignar.jsx
+++ b/frontend/src/components/logistica/ModalFormAsignar.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  Alert,
+} from '@mui/material';
+import { getCamiones, getComandasActivas, updateComanda } from '../../api/comandas';
+
+const calcularBultos = (comanda) => {
+  if (!Array.isArray(comanda?.items)) return 0;
+  return comanda.items.reduce((sum, item) => sum + (item.cantidad || 0), 0);
+};
+
+const calcularVolumen = (comanda) => {
+  if (!Array.isArray(comanda?.items)) return 0;
+  return comanda.items.reduce((sum, item) => {
+    const prod = item.codprod || {};
+    const volumen = prod.volumen || prod.m3 || prod.metrosCubicos || 0;
+    return sum + (Number(volumen) || 0) * (item.cantidad || 0);
+  }, 0);
+};
+
+const capacidadDisponible = (camion) => ({
+  volumen: camion?.capacidadVolumen || camion?.volumen || 0,
+  bultos: camion?.capacidadBultos || camion?.capacidad || 0,
+});
+
+export default function ModalFormAsignar({ open, onClose, onAssigned }) {
+  const [camiones, setCamiones] = useState([]);
+  const [comandas, setComandas] = useState([]);
+  const [selectedComandaId, setSelectedComandaId] = useState('');
+  const [selectedCamionId, setSelectedCamionId] = useState('');
+  const [motivo, setMotivo] = useState('');
+  const [errorCapacidad, setErrorCapacidad] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const fetchData = async () => {
+      try {
+        const [camionesData, comandasData] = await Promise.all([
+          getCamiones(),
+          getComandasActivas({ limite: 400 }),
+        ]);
+        setCamiones(camionesData);
+        setComandas(
+          comandasData.filter((c) => c.estadoPreparacion === 'Lista para carga' && c.activo !== false)
+        );
+      } catch (err) {
+        console.error('Error cargando datos de logística', err);
+      }
+    };
+    fetchData();
+  }, [open]);
+
+  const comandaSeleccionada = useMemo(
+    () => comandas.find((c) => c._id === selectedComandaId),
+    [comandas, selectedComandaId]
+  );
+  const camionSeleccionado = useMemo(
+    () => camiones.find((c) => c._id === selectedCamionId),
+    [camiones, selectedCamionId]
+  );
+
+  useEffect(() => {
+    if (!comandaSeleccionada || !camionSeleccionado) {
+      setErrorCapacidad('');
+      return;
+    }
+    const cargaVolumen = calcularVolumen(comandaSeleccionada);
+    const cargaBultos = calcularBultos(comandaSeleccionada);
+    const capacidad = capacidadDisponible(camionSeleccionado);
+    if ((capacidad.volumen && cargaVolumen > capacidad.volumen) || (capacidad.bultos && cargaBultos > capacidad.bultos)) {
+      setErrorCapacidad(
+        `La carga supera la capacidad disponible del camión. Volumen requerido: ${cargaVolumen.toFixed(
+          2
+        )} / Capacidad: ${capacidad.volumen || 's/d'} | Bultos: ${cargaBultos} / Capacidad: ${capacidad.bultos || 's/d'}`
+      );
+    } else {
+      setErrorCapacidad('');
+    }
+  }, [comandaSeleccionada, camionSeleccionado]);
+
+  const handleAssign = async () => {
+    if (!comandaSeleccionada || !camionSeleccionado) return;
+    try {
+      setSaving(true);
+      await updateComanda(comandaSeleccionada._id, {
+        camion: camionSeleccionado._id,
+        usuarioLogistica: currentUserId,
+        motivoLogistica: motivo || undefined,
+        motivoHistorial: 'Asignación logística',
+      });
+      if (typeof onAssigned === 'function') onAssigned();
+      setSelectedCamionId('');
+      setSelectedComandaId('');
+      setMotivo('');
+    } catch (err) {
+      console.error('Error asignando comanda a camión', err);
+      alert('No se pudo asignar la comanda.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Asignar comanda a camión</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="comanda-label">Comanda</InputLabel>
+            <Select
+              labelId="comanda-label"
+              label="Comanda"
+              value={selectedComandaId}
+              onChange={(event) => setSelectedComandaId(event.target.value)}
+            >
+              {comandas.map((comanda) => (
+                <MenuItem key={comanda._id} value={comanda._id}>
+                  #{comanda.nrodecomanda} — {comanda.codcli?.razonsocial}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel id="camion-label">Camión</InputLabel>
+            <Select
+              labelId="camion-label"
+              label="Camión"
+              value={selectedCamionId}
+              onChange={(event) => setSelectedCamionId(event.target.value)}
+            >
+              {camiones.map((camion) => (
+                <MenuItem key={camion._id} value={camion._id}>
+                  {camion.camion || camion.patente}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {comandaSeleccionada && (
+            <Typography variant="body2" color="text.secondary">
+              Bultos: {calcularBultos(comandaSeleccionada)} — Volumen estimado: {calcularVolumen(comandaSeleccionada).toFixed(2)}
+            </Typography>
+          )}
+          {errorCapacidad && <Alert severity="warning">{errorCapacidad}</Alert>}
+          <TextField
+            label="Motivo / notas"
+            value={motivo}
+            onChange={(event) => setMotivo(event.target.value)}
+            fullWidth
+            multiline
+            minRows={2}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button
+          onClick={handleAssign}
+          disabled={!selectedCamionId || !selectedComandaId || saving}
+          variant="contained"
+        >
+          Confirmar asignación
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/logistica/ModalFormCamion.jsx
+++ b/frontend/src/components/logistica/ModalFormCamion.jsx
@@ -1,0 +1,166 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { updateComanda } from '../../api/comandas';
+
+const ESTADOS_ENTREGA = [
+  { value: 'Completada', label: 'Completada' },
+  { value: 'Parcial', label: 'Entrega parcial' },
+  { value: 'Rechazada', label: 'Rechazada' },
+];
+
+export default function ModalFormCamion({ open, comanda, onClose, onSaved }) {
+  const [estadoEntrega, setEstadoEntrega] = useState('Completada');
+  const [motivo, setMotivo] = useState('');
+  const [observaciones, setObservaciones] = useState('');
+  const [checklistConfirmado, setChecklistConfirmado] = useState(true);
+  const [fotos, setFotos] = useState([]);
+  const [fotoActual, setFotoActual] = useState({ nombre: '', url: '' });
+  const [saving, setSaving] = useState(false);
+
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+
+  const handleAgregarFoto = () => {
+    if (!fotoActual.url) return;
+    setFotos((prev) => [...prev, { ...fotoActual }]);
+    setFotoActual({ nombre: '', url: '' });
+  };
+
+  const handleRemoveFoto = (index) => {
+    setFotos((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSubmit = async () => {
+    if (!comanda) return;
+    try {
+      setSaving(true);
+      await updateComanda(comanda._id, {
+        entregaNueva: {
+          estado: estadoEntrega,
+          motivo: motivo || undefined,
+          observaciones: observaciones || undefined,
+          checklistConfirmado,
+          fotos,
+          fecha: new Date().toISOString(),
+          usuario: currentUserId,
+        },
+        motivoHistorial: `Entrega ${estadoEntrega.toLowerCase()}`,
+      });
+      if (typeof onSaved === 'function') onSaved();
+      setEstadoEntrega('Completada');
+      setMotivo('');
+      setObservaciones('');
+      setChecklistConfirmado(true);
+      setFotos([]);
+    } catch (err) {
+      console.error('Error registrando entrega', err);
+      alert('No se pudo registrar la entrega.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Registrar entrega — Comanda #{comanda?.nrodecomanda}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <TextField
+            select
+            label="Estado de entrega"
+            value={estadoEntrega}
+            onChange={(event) => setEstadoEntrega(event.target.value)}
+          >
+            {ESTADOS_ENTREGA.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Motivo"
+            value={motivo}
+            onChange={(event) => setMotivo(event.target.value)}
+            fullWidth
+            multiline
+            minRows={2}
+            helperText="Describe el motivo de la entrega parcial o rechazo"
+          />
+          <TextField
+            label="Observaciones"
+            value={observaciones}
+            onChange={(event) => setObservaciones(event.target.value)}
+            fullWidth
+            multiline
+            minRows={2}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={checklistConfirmado}
+                onChange={(event) => setChecklistConfirmado(event.target.checked)}
+              />
+            }
+            label="Checklist leído por el cliente"
+          />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+            <TextField
+              label="Nombre foto"
+              value={fotoActual.nombre}
+              onChange={(event) => setFotoActual((prev) => ({ ...prev, nombre: event.target.value }))}
+              size="small"
+            />
+            <TextField
+              label="URL foto"
+              value={fotoActual.url}
+              onChange={(event) => setFotoActual((prev) => ({ ...prev, url: event.target.value }))}
+              size="small"
+              fullWidth
+            />
+            <Button onClick={handleAgregarFoto} size="small" variant="outlined">
+              Agregar
+            </Button>
+          </Stack>
+          <List dense>
+            {fotos.map((foto, index) => (
+              <ListItem key={`${foto.url}-${index}`} secondaryAction={
+                <IconButton edge="end" onClick={() => handleRemoveFoto(index)}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              }>
+                <ListItemText primary={foto.nombre || `Foto ${index + 1}`} secondary={foto.url} />
+              </ListItem>
+            ))}
+            {fotos.length === 0 && (
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                Sin fotos cargadas
+              </Typography>
+            )}
+          </List>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cerrar</Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={saving}>
+          Guardar entrega
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/logistica/PreparacionDrawer.jsx
+++ b/frontend/src/components/logistica/PreparacionDrawer.jsx
@@ -1,0 +1,301 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  IconButton,
+  Chip,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import dayjs from 'dayjs';
+import { getUsuarios, updateComanda } from '../../api/comandas';
+
+const formatDateTimeLocal = (value) => {
+  if (!value) return '';
+  return dayjs(value).format('YYYY-MM-DDTHH:mm');
+};
+
+const parseDateTimeLocal = (value) => {
+  if (!value) return undefined;
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.toISOString() : undefined;
+};
+
+export default function PreparacionDrawer({ open, comanda, onClose, onSaved }) {
+  const [usuarios, setUsuarios] = useState([]);
+  const [loadingUsuarios, setLoadingUsuarios] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    responsable: '',
+    inicio: '',
+    fin: '',
+    verificacionBultos: false,
+    controlTemperatura: '',
+    incidencias: '',
+    archivos: [],
+  });
+  const [nuevoArchivo, setNuevoArchivo] = useState({ nombre: '', url: '' });
+
+  const currentUserId = useMemo(() => localStorage.getItem('id'), []);
+  const asignadoId = comanda?.operarioAsignado?._id || comanda?.operarioAsignado || null;
+  const puedeFinalizar = asignadoId && String(asignadoId) === String(currentUserId);
+
+  useEffect(() => {
+    if (!open) return;
+    const cargarUsuarios = async () => {
+      try {
+        setLoadingUsuarios(true);
+        const data = await getUsuarios();
+        setUsuarios(data);
+      } catch (error) {
+        console.error('Error cargando usuarios', error);
+      } finally {
+        setLoadingUsuarios(false);
+      }
+    };
+    cargarUsuarios();
+  }, [open]);
+
+  useEffect(() => {
+    if (!comanda) return;
+    const prep = comanda.preparacion || {};
+    setForm({
+      responsable: prep.responsable?._id || prep.responsable || asignadoId || currentUserId || '',
+      inicio: formatDateTimeLocal(prep.inicio),
+      fin: formatDateTimeLocal(prep.fin),
+      verificacionBultos: Boolean(prep.verificacionBultos),
+      controlTemperatura: prep.controlTemperatura || '',
+      incidencias: prep.incidencias || '',
+      archivos: Array.isArray(prep.archivos) ? prep.archivos : [],
+    });
+  }, [comanda, asignadoId, currentUserId]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCheckbox = (event) => {
+    const { name, checked } = event.target;
+    setForm((prev) => ({ ...prev, [name]: checked }));
+  };
+
+  const handleAgregarArchivo = () => {
+    if (!nuevoArchivo.nombre || !nuevoArchivo.url) return;
+    setForm((prev) => ({ ...prev, archivos: [...prev.archivos, { ...nuevoArchivo }] }));
+    setNuevoArchivo({ nombre: '', url: '' });
+  };
+
+  const handleRemoveArchivo = (index) => {
+    setForm((prev) => ({
+      ...prev,
+      archivos: prev.archivos.filter((_, idx) => idx !== index),
+    }));
+  };
+
+  const buildPayload = (estadoPreparacion) => {
+    const payload = {
+      preparacion: {
+        responsable: form.responsable || undefined,
+        inicio: parseDateTimeLocal(form.inicio),
+        fin: parseDateTimeLocal(form.fin),
+        verificacionBultos: form.verificacionBultos,
+        controlTemperatura: form.controlTemperatura || undefined,
+        incidencias: form.incidencias || undefined,
+        archivos: form.archivos,
+      },
+      motivoHistorial: 'Actualización checklist de depósito',
+    };
+    if (estadoPreparacion) payload.estadoPreparacion = estadoPreparacion;
+    return payload;
+  };
+
+  const handleSave = async (estadoPreparacion) => {
+    if (!comanda) return;
+    if (!form.responsable) {
+      alert('Seleccioná un responsable.');
+      return;
+    }
+    if (!form.inicio) {
+      alert('Indicá la hora de inicio.');
+      return;
+    }
+    if (estadoPreparacion === 'Lista para carga' && !form.fin) {
+      setForm((prev) => ({ ...prev, fin: formatDateTimeLocal(new Date()) }));
+    }
+    try {
+      setSaving(true);
+      const payload = buildPayload(estadoPreparacion);
+      if (estadoPreparacion === 'Lista para carga' && !payload.preparacion.fin) {
+        payload.preparacion.fin = new Date().toISOString();
+      }
+      await updateComanda(comanda._id, payload);
+      if (typeof onSaved === 'function') onSaved();
+    } catch (error) {
+      console.error('Error guardando checklist', error);
+      alert('No se pudo guardar la preparación.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const assignedUserLabel = useMemo(() => {
+    if (!comanda?.operarioAsignado) return 'Sin asignar';
+    if (typeof comanda.operarioAsignado === 'string') return comanda.operarioAsignado;
+    const { nombres, apellidos } = comanda.operarioAsignado;
+    return [nombres, apellidos].filter(Boolean).join(' ') || 'Asignado';
+  }, [comanda]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        Checklist de preparación
+        <Typography variant="subtitle2" color="text.secondary">
+          Comanda #{comanda?.nrodecomanda} — Operario: {assignedUserLabel}
+        </Typography>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="responsable-label">Responsable</InputLabel>
+            <Select
+              labelId="responsable-label"
+              name="responsable"
+              label="Responsable"
+              value={form.responsable}
+              onChange={handleChange}
+              disabled={loadingUsuarios}
+            >
+              {usuarios.map((user) => (
+                <MenuItem key={user._id} value={user._id}>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <span>{user.nombres} {user.apellidos}</span>
+                    {user.role && <Chip size="small" label={user.role} />}
+                  </Stack>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <TextField
+              label="Inicio"
+              type="datetime-local"
+              name="inicio"
+              value={form.inicio}
+              onChange={handleChange}
+              fullWidth
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Fin"
+              type="datetime-local"
+              name="fin"
+              value={form.fin}
+              onChange={handleChange}
+              fullWidth
+              InputLabelProps={{ shrink: true }}
+            />
+          </Stack>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={form.verificacionBultos}
+                name="verificacionBultos"
+                onChange={handleCheckbox}
+              />
+            }
+            label="Verificación de bultos realizada"
+          />
+          <TextField
+            label="Control de temperatura"
+            name="controlTemperatura"
+            value={form.controlTemperatura}
+            onChange={handleChange}
+            fullWidth
+          />
+          <TextField
+            label="Incidencias"
+            name="incidencias"
+            value={form.incidencias}
+            onChange={handleChange}
+            fullWidth
+            multiline
+            minRows={2}
+          />
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Evidencias / archivos
+            </Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+              <TextField
+                label="Nombre"
+                value={nuevoArchivo.nombre}
+                onChange={(event) => setNuevoArchivo((prev) => ({ ...prev, nombre: event.target.value }))}
+                size="small"
+              />
+              <TextField
+                label="URL"
+                value={nuevoArchivo.url}
+                onChange={(event) => setNuevoArchivo((prev) => ({ ...prev, url: event.target.value }))}
+                size="small"
+                fullWidth
+              />
+              <Button variant="outlined" onClick={handleAgregarArchivo} size="small">
+                Agregar
+              </Button>
+            </Stack>
+            <List dense>
+              {form.archivos.map((archivo, index) => (
+                <ListItem key={`${archivo.url}-${index}`}>
+                  <ListItemText primary={archivo.nombre} secondary={archivo.url} />
+                  <ListItemSecondaryAction>
+                    <IconButton edge="end" onClick={() => handleRemoveArchivo(index)}>
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+              {form.archivos.length === 0 && (
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                  Sin archivos adjuntos
+                </Typography>
+              )}
+            </List>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 3, py: 2 }}>
+        <Button onClick={onClose}>Cerrar</Button>
+        <Stack direction="row" spacing={1}>
+          <Button onClick={() => handleSave()} disabled={saving} variant="outlined">
+            Guardar checklist
+          </Button>
+          <Button
+            onClick={() => handleSave('Lista para carga')}
+            disabled={!puedeFinalizar || saving}
+            variant="contained"
+          >
+            Marcar lista para carga
+          </Button>
+        </Stack>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -1,6 +1,80 @@
-import React from 'react';
-import { Typography } from '@mui/material';
+import React, { useState } from 'react';
+import { Box, Button, Card, CardContent, Grid, Stack, Typography } from '@mui/material';
+import AppOrdenAPrepararReactTable from '../components/logistica/AppOrdenAPrepararReactTable.jsx';
+import KanbanPreparacion from '../components/logistica/KanbanPreparacion.jsx';
+import AppCamionReactTable from '../components/logistica/AppCamionReactTable.jsx';
+import AppGestionReactTable from '../components/logistica/AppGestionReactTable.jsx';
+import ModalFormAsignar from '../components/logistica/ModalFormAsignar.jsx';
+
+const formatMinutes = (minutes) => `${minutes.toFixed(1)} min`;
 
 export default function LogisticsPage() {
-  return <Typography>Panel logístico en tiempo real (pendiente)</Typography>;
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [metrics, setMetrics] = useState({
+    tiempoPromedioPreparacion: 0,
+    demoraPromedioDespacho: 0,
+    porcentajeEntregasParciales: 0,
+  });
+
+  const handleRefresh = () => setRefreshKey((prev) => prev + 1);
+
+  return (
+    <Stack spacing={4}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
+        <Typography variant="h4" sx={{ flexGrow: 1 }}>
+          Logística y depósito
+        </Typography>
+        <Button variant="contained" onClick={() => setAssignOpen(true)}>
+          Asignar comanda a camión
+        </Button>
+      </Stack>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8}>
+          <AppOrdenAPrepararReactTable
+            onDataChange={() => {}}
+            onManualRefresh={handleRefresh}
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6">Métricas claves</Typography>
+              <Stack spacing={2} sx={{ mt: 2 }}>
+                <Box>
+                  <Typography variant="subtitle2">Tiempo promedio de preparación</Typography>
+                  <Typography variant="h5">{formatMinutes(metrics.tiempoPromedioPreparacion)}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="subtitle2">Demora entre preparación y despacho</Typography>
+                  <Typography variant="h5">{formatMinutes(metrics.demoraPromedioDespacho)}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="subtitle2">Entregas parciales / rechazadas</Typography>
+                  <Typography variant="h5">{metrics.porcentajeEntregasParciales.toFixed(1)}%</Typography>
+                </Box>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <KanbanPreparacion refreshKey={refreshKey} />
+      <AppCamionReactTable refreshKey={refreshKey} />
+      <AppGestionReactTable
+        refreshKey={refreshKey}
+        onMetricsCalculated={(data) => setMetrics(data)}
+      />
+
+      <ModalFormAsignar
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        onAssigned={() => {
+          setAssignOpen(false);
+          handleRefresh();
+        }}
+      />
+    </Stack>
+  );
 }


### PR DESCRIPTION
## Summary
- extend the Mongoose comanda schema with preparation, control de carga, logística and delivery subdocuments plus historial entries
- update PUT /comandas logic to validate critical transitions, register audit entries and keep role-based permissions, and document the end-to-end flow
- add new logistics UI modules with polling, kanban board, control de carga modal, camion/chofer workflow and administrative tracking metrics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4254ca55883219df72860a9e6701d