### PR TITLE
feat: logistics management view with advanced filters

### DIFF
--- a/backend/server/modelos/comanda.js
+++ b/backend/server/modelos/comanda.js
@@ -76,6 +76,11 @@ const comandaSchema = new Schema({
     ref: "Usuario",
   },
 
+  puntoDistribucion: {
+    type: String,
+    trim: true,
+  },
+
   activo: {
     type: Boolean,
     default: true,

--- a/backend/server/rutas/comanda.js
+++ b/backend/server/rutas/comanda.js
@@ -3,7 +3,9 @@
 // Compatible con Node.js v22.17.1 y Mongoose v8.16.5
 
 const express = require('express');
+const mongoose = require('mongoose');
 const Comanda = require('../modelos/comanda');
+const Cliente = require('../modelos/cliente');
 const Producserv = require('../modelos/producserv');
 const Stock = require('../modelos/stock');
 const Tipomovimiento = require('../modelos/tipomovimiento');
@@ -26,6 +28,14 @@ const asyncHandler = (fn) => (req, res, next) => {
 };
 
 const toNumber = (v, def) => Number(v ?? def);
+
+const parseDate = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const isValidObjectId = (value) => mongoose.Types.ObjectId.isValid(value);
 
 /**
  * Conjunto de poblados comunes a la mayoría de endpoints.
@@ -76,6 +86,137 @@ router.get('/comandasactivas', asyncHandler(async (req, res) => {
     .exec();
   const cantidad = await Comanda.countDocuments(query);
   res.json({ ok: true, comandas, cantidad });
+}));
+
+// -----------------------------------------------------------------------------
+// 2.a. COMANDAS PARA LOGÍSTICA -------------------------------------------------
+// -----------------------------------------------------------------------------
+router.get('/comandas/logistica', [verificaToken, verificaAdminCam_role], asyncHandler(async (req, res) => {
+  const page = Math.max(toNumber(req.query.page, 1), 1);
+  const requestedLimit = Math.max(toNumber(req.query.limit, 20), 1);
+  const limit = Math.min(requestedLimit, 20); // Siempre máximo 20 por página
+  const skip = (page - 1) * limit;
+
+  const {
+    fechaDesde,
+    fechaHasta,
+    cliente,
+    producto,
+    ruta,
+    camionero,
+    estado,
+    usuario,
+    nrocomanda,
+    puntoDistribucion,
+  } = req.query;
+
+  const filters = [{ activo: true }];
+
+  const from = parseDate(fechaDesde);
+  const to = parseDate(fechaHasta);
+  if (from || to) {
+    const rango = {};
+    if (from) rango.$gte = from;
+    if (to) {
+      // Ajusta al final del día para incluir registros completos
+      const end = new Date(to);
+      end.setHours(23, 59, 59, 999);
+      rango.$lte = end;
+    }
+    filters.push({ fecha: rango });
+  }
+
+  if (nrocomanda) {
+    const nro = Number(nrocomanda);
+    if (!Number.isNaN(nro)) filters.push({ nrodecomanda: nro });
+  }
+
+  if (cliente) {
+    if (!isValidObjectId(cliente)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ codcli: cliente });
+  }
+
+  if (producto) {
+    if (!isValidObjectId(producto)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ 'items.codprod': producto });
+  }
+
+  if (camionero) {
+    if (!isValidObjectId(camionero)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ camionero });
+  }
+
+  if (estado) {
+    if (!isValidObjectId(estado)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ codestado: estado });
+  }
+
+  if (usuario) {
+    if (!isValidObjectId(usuario)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ usuario });
+  }
+  if (puntoDistribucion) {
+    filters.push({ puntoDistribucion: { $regex: new RegExp(puntoDistribucion, 'i') } });
+  }
+
+  if (ruta) {
+    if (!isValidObjectId(ruta)) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    const clientes = await Cliente.find({ ruta }).select('_id').lean().exec();
+    const ids = clientes.map((c) => c._id);
+    if (!ids.length) {
+      return res.json({ ok: true, page, limit, total: 0, totalPages: 0, comandas: [] });
+    }
+    filters.push({ codcli: { $in: ids } });
+  }
+
+  const query = filters.length === 1 ? filters[0] : { $and: filters };
+
+  const [total, comandas] = await Promise.all([
+    Comanda.countDocuments(query),
+    Comanda.find(query)
+      .sort({ fecha: -1, nrodecomanda: -1 })
+      .skip(skip)
+      .limit(limit)
+      .populate([
+        {
+          path: 'codcli',
+          populate: [
+            { path: 'ruta' },
+            { path: 'localidad', populate: { path: 'provincia' } },
+          ],
+        },
+        { path: 'items.lista' },
+        {
+          path: 'items.codprod',
+          populate: [
+            { path: 'marca' },
+            { path: 'unidaddemedida' },
+          ],
+        },
+        { path: 'codestado' },
+        { path: 'camion' },
+        { path: 'usuario', select: 'nombres apellidos role email' },
+        { path: 'camionero', select: 'nombres apellidos role email' },
+      ])
+      .lean()
+      .exec(),
+  ]);
+
+  const totalPages = Math.ceil(total / limit) || 0;
+
+  res.json({ ok: true, page, limit, total, totalPages, comandas });
 }));
 
 // -----------------------------------------------------------------------------
@@ -257,6 +398,7 @@ router.post('/comandas',  asyncHandler(async (req, res) => {
         fechadeentrega: body.fechadeentrega,
         usuario: body.usuario,
         camionero: body.camionero,
+        puntoDistribucion: body.puntoDistribucion,
         activo: body.activo,
         items: body.items,
       });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
         "axios": "^1.6.8",
         "dayjs": "^1.11.10",
         "framer-motion": "^11.18.2",
+        "jspdf": "^2.5.1",
+        "jspdf-autotable": "^3.8.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.23.1",
@@ -2174,6 +2176,13 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -2292,6 +2301,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -2324,6 +2345,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2369,6 +2400,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2411,6 +2454,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2484,6 +2547,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2522,6 +2597,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2578,6 +2663,13 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2971,6 +3063,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3264,6 +3362,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3420,6 +3532,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-3.8.4.tgz",
+      "integrity": "sha512-rSffGoBsJYX83iTRv8Ft7FhqfgEL2nLpGAIiqruEQQ3e4r0qdLFbPUB7N9HAle0I3XgpisvyW751VHCqKUVOgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2.5.1"
       }
     },
     "node_modules/keyv": {
@@ -3718,6 +3857,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3809,6 +3955,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -3894,6 +4050,13 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -3927,6 +4090,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -4089,6 +4262,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4131,6 +4314,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -4217,6 +4420,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "@mui/x-data-grid": "^8.9.1",
     "@tanstack/react-table": "^8.21.3",
     "axios": "^1.6.8",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.8.2",
     "dayjs": "^1.11.10",
     "framer-motion": "^11.18.2",
     "react": "^19.1.0",

--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -4,6 +4,7 @@ import ClientsPage from './pages/ClientsPage';
 import ProductsPage from './pages/ProductsPage.jsx';
 import ComandasPage from './pages/ComandasPage.jsx';
 import DocumentsPage from './pages/DocumentsPage.jsx';
+import LogisticsPage from './pages/LogisticsPage.jsx';
 import LoginForm from './pages/LoginForm';
 import PrivateRoute from './components/PrivateRoute';
 import HistorialComandas from './components/HistorialComandas.jsx';
@@ -25,6 +26,7 @@ export default function AppRoutes({ themeName, setThemeName }) {
         <Route path="/documents" element={<DocumentsPage />} />
         <Route path="comandas" element={<ComandasPage />} />
         <Route path="/historial-comandas" element={<HistorialComandas />} />
+        <Route path="/logistics" element={<LogisticsPage />} />
         {/* Otras rutas aquí */}
       </Route>
     </Routes>

--- a/frontend/src/components/logistics/DeleteConfirmationDialog.jsx
+++ b/frontend/src/components/logistics/DeleteConfirmationDialog.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+
+export default function DeleteConfirmationDialog({ open, onClose, onConfirm, comandas = [], loading = false }) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Eliminar comandas seleccionadas</DialogTitle>
+      <DialogContent dividers>
+        <DialogContentText sx={{ mb: 2 }}>
+          Se realizará una baja lógica de las siguientes comandas. Esta acción puede revertirse desde otros módulos del sistema.
+        </DialogContentText>
+        <List dense>
+          {comandas.map((comanda) => (
+            <ListItem key={comanda?._id ?? comanda?.nrodecomanda}>
+              <ListItemText
+                primary={`#${comanda?.nrodecomanda ?? 'N/D'} — ${comanda?.codcli?.razonsocial ?? 'Cliente'}`}
+                secondary={`Producto principal: ${comanda?.items?.[0]?.codprod?.descripcion ?? 'Sin información'} — Fecha: ${new Date(comanda?.fecha ?? '').toLocaleDateString()}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="inherit" disabled={loading}>
+          Cancelar
+        </Button>
+        <Button onClick={onConfirm} variant="contained" color="error" disabled={loading}>
+          {loading ? 'Eliminando…' : 'Eliminar seleccionadas'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/logistics/ItemsModal.jsx
+++ b/frontend/src/components/logistics/ItemsModal.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+const formatNumber = (value) => new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+}).format(Number(value ?? 0));
+
+export default function ItemsModal({ open, onClose, comanda }) {
+  const items = Array.isArray(comanda?.items) ? comanda.items : [];
+  const cliente = comanda?.codcli?.razonsocial ?? '—';
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', pr: 6 }}>
+        Detalle de ítems — Comanda #{comanda?.nrodecomanda ?? 'N/D'}
+        <IconButton onClick={onClose} sx={{ ml: 'auto' }} aria-label="Cerrar">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Cliente
+          </Typography>
+          <Typography variant="body1">{cliente}</Typography>
+        </Box>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Producto</TableCell>
+              <TableCell>Lista</TableCell>
+              <TableCell align="right">Cant. solicitada</TableCell>
+              <TableCell align="right">Cant. entregada</TableCell>
+              <TableCell align="right">Precio unitario</TableCell>
+              <TableCell align="right">Subtotal</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center">
+                  <Typography variant="body2" color="text.secondary">
+                    La comanda no posee ítems registrados.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              items.map((item) => {
+                const descripcion = item?.codprod?.descripcion ?? '—';
+                const lista = item?.lista?.lista ?? '—';
+                const cantidadSolicitada = Number(item?.cantidad ?? 0);
+                const cantidadEntregada = Number(item?.cantidadentregada ?? 0);
+                const precio = Number(item?.monto ?? 0);
+                const subtotal = cantidadEntregada * precio;
+                return (
+                  <TableRow key={item?._id ?? `${descripcion}-${lista}`}>
+                    <TableCell>{descripcion}</TableCell>
+                    <TableCell>{lista}</TableCell>
+                    <TableCell align="right">{formatNumber(cantidadSolicitada)}</TableCell>
+                    <TableCell align="right">{formatNumber(cantidadEntregada)}</TableCell>
+                    <TableCell align="right">${formatNumber(precio)}</TableCell>
+                    <TableCell align="right">${formatNumber(subtotal)}</TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          Cerrar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/logistics/LogisticsActionDialog.jsx
+++ b/frontend/src/components/logistics/LogisticsActionDialog.jsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+} from '@mui/material';
+
+const buildOption = (item, getLabel) => ({
+  id: item?._id,
+  label: getLabel(item),
+  raw: item,
+});
+
+const mapOptions = (collection = [], getLabel) =>
+  collection
+    .filter(Boolean)
+    .map((item) => buildOption(item, getLabel))
+    .filter((opt) => Boolean(opt.id));
+
+export default function LogisticsActionDialog({
+  open,
+  onClose,
+  onSubmit,
+  comandas = [],
+  estados = [],
+  camioneros = [],
+  camiones = [],
+  loading = false,
+}) {
+  const initialValues = useMemo(() => {
+    const first = comandas[0] ?? {};
+    const estadoActual = first?.codestado ? buildOption(first.codestado, (e) => e.estado ?? '—') : null;
+    const camioneroActual = first?.camionero
+      ? buildOption(first.camionero, (u) => `${u.nombres ?? ''} ${u.apellidos ?? ''}`.trim())
+      : null;
+    const camionActual = first?.camion
+      ? buildOption(first.camion, (c) => c.camion ?? '—')
+      : null;
+    return {
+      estado: estadoActual,
+      camionero: camioneroActual,
+      camion: camionActual,
+      puntoDistribucion: first?.puntoDistribucion ?? camionActual?.label ?? '',
+    };
+  }, [comandas]);
+
+  const [estadoSel, setEstadoSel] = useState(null);
+  const [camioneroSel, setCamioneroSel] = useState(null);
+  const [camionSel, setCamionSel] = useState(null);
+  const [puntoDistribucion, setPuntoDistribucion] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setEstadoSel(initialValues.estado);
+      setCamioneroSel(initialValues.camionero);
+      setCamionSel(initialValues.camion);
+      setPuntoDistribucion(initialValues.puntoDistribucion ?? '');
+    }
+  }, [open, initialValues]);
+
+  useEffect(() => {
+    if (camionSel?.label && !puntoDistribucion) {
+      setPuntoDistribucion(camionSel.label);
+    }
+  }, [camionSel, puntoDistribucion]);
+
+  const estadoOptions = useMemo(() => mapOptions(estados, (e) => e.estado ?? '—'), [estados]);
+  const camioneroOptions = useMemo(
+    () => mapOptions(camioneros, (u) => `${u.nombres ?? ''} ${u.apellidos ?? ''}`.trim()),
+    [camioneros],
+  );
+  const camionOptions = useMemo(() => mapOptions(camiones, (c) => c.camion ?? '—'), [camiones]);
+
+  const handleSubmit = (evt) => {
+    evt?.preventDefault?.();
+    onSubmit?.({
+      estado: estadoSel?.id ?? null,
+      camionero: camioneroSel?.id ?? null,
+      camion: camionSel?.id ?? null,
+      puntoDistribucion: puntoDistribucion?.trim() || null,
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Asignar logística</DialogTitle>
+      <DialogContent dividers>
+        <DialogContentText sx={{ mb: 2 }}>
+          Confirmá el estado logístico y las asignaciones para las siguientes comandas.
+        </DialogContentText>
+        <List dense sx={{ mb: 3, bgcolor: 'background.paper', borderRadius: 1 }}>
+          {comandas.map((comanda) => (
+            <ListItem key={comanda?._id ?? comanda?.nrodecomanda}>
+              <ListItemText
+                primary={`#${comanda?.nrodecomanda ?? 'N/D'} — ${comanda?.codcli?.razonsocial ?? 'Cliente sin nombre'}`}
+                secondary={`Estado actual: ${comanda?.codestado?.estado ?? 'Sin estado asignado'}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+        <Box component="form" onSubmit={handleSubmit}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <Autocomplete
+                value={estadoSel}
+                options={estadoOptions}
+                onChange={(_, value) => setEstadoSel(value)}
+                renderInput={(params) => <TextField {...params} label="Estado logístico" required />}
+                isOptionEqualToValue={(opt, val) => opt.id === val.id}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Autocomplete
+                value={camioneroSel}
+                options={camioneroOptions}
+                onChange={(_, value) => setCamioneroSel(value)}
+                renderInput={(params) => (
+                  <TextField {...params} label="Camionero / Chofer" placeholder="Buscar" />
+                )}
+                isOptionEqualToValue={(opt, val) => opt.id === val.id}
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Autocomplete
+                value={camionSel}
+                options={camionOptions}
+                onChange={(_, value) => {
+                  setCamionSel(value);
+                  if (value?.label) setPuntoDistribucion(value.label);
+                }}
+                renderInput={(params) => <TextField {...params} label="Punto de distribución" />}
+                isOptionEqualToValue={(opt, val) => opt.id === val.id}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                label="Detalle del punto de distribución"
+                value={puntoDistribucion}
+                onChange={(event) => setPuntoDistribucion(event.target.value)}
+                placeholder="Depósito, centro logístico, etc."
+              />
+            </Grid>
+          </Grid>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="inherit" disabled={loading}>
+          Cancelar
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={loading}>
+          {loading ? 'Guardando…' : 'Confirmar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -1,6 +1,977 @@
-import React from 'react';
-import { Typography } from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  Grid,
+  IconButton,
+  LinearProgress,
+  Link,
+  Paper,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import dayjs from 'dayjs';
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import api from '../api/axios';
+import ItemsModal from '../components/logistics/ItemsModal.jsx';
+import LogisticsActionDialog from '../components/logistics/LogisticsActionDialog.jsx';
+import DeleteConfirmationDialog from '../components/logistics/DeleteConfirmationDialog.jsx';
+
+const PAGE_SIZE = 20;
+const columnHelper = createColumnHelper();
+
+const numberFormatter = new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const currencyFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  minimumFractionDigits: 2,
+});
+
+const sumDelivered = (items = []) =>
+  items.reduce((acc, item) => acc + Number(item?.cantidadentregada ?? 0), 0);
+
+const sumDeliveredTotal = (items = []) =>
+  items.reduce(
+    (acc, item) =>
+      acc + Number(item?.cantidadentregada ?? 0) * Number(item?.monto ?? 0),
+    0,
+  );
+
+const extractPrimaryProduct = (items = []) => items?.[0]?.codprod?.descripcion ?? '—';
+
+const buildOption = (entity, labelFn) => {
+  if (!entity?._id) return null;
+  return {
+    id: entity._id,
+    label: labelFn(entity),
+    raw: entity,
+  };
+};
+
+const safeGetFilterValue = (column) => column?.getFilterValue?.() ?? null;
 
 export default function LogisticsPage() {
-  return <Typography>Panel logístico en tiempo real (pendiente)</Typography>;
+  const [data, setData] = useState([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [columnFilters, setColumnFilters] = useState([]);
+  const [rowSelection, setRowSelection] = useState({});
+  const [itemsModal, setItemsModal] = useState({ open: false, comanda: null });
+  const [logisticsDialog, setLogisticsDialog] = useState({ open: false, comandas: [] });
+  const [deleteDialog, setDeleteDialog] = useState({ open: false, comandas: [] });
+  const [savingLogistics, setSavingLogistics] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+
+  const [estados, setEstados] = useState([]);
+  const [camiones, setCamiones] = useState([]);
+  const [rutas, setRutas] = useState([]);
+  const [camioneros, setCamioneros] = useState([]);
+
+  const [clienteOptions, setClienteOptions] = useState([]);
+  const [productoOptions, setProductoOptions] = useState([]);
+  const [usuarioOptions, setUsuarioOptions] = useState([]);
+  const clienteCache = useRef(new Map());
+  const productoCache = useRef(new Map());
+  const clienteAbort = useRef(null);
+  const productoAbort = useRef(null);
+  const clienteTimer = useRef(null);
+  const productoTimer = useRef(null);
+  const camioneroTimer = useRef(null);
+  const usuarioTimer = useRef(null);
+
+  const columns = useMemo(() => [
+      {
+        id: 'select',
+        size: 48,
+        header: ({ table: tbl }) => (
+          <Checkbox
+            indeterminate={tbl.getIsSomePageRowsSelected()}
+            checked={tbl.getIsAllPageRowsSelected()}
+            onChange={tbl.getToggleAllPageRowsSelectedHandler()}
+            inputProps={{ 'aria-label': 'Seleccionar todas las comandas de la página' }}
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            indeterminate={row.getIsSomeSelected()}
+            onChange={row.getToggleSelectedHandler()}
+            inputProps={{ 'aria-label': `Seleccionar comanda ${row.original?.nrodecomanda ?? ''}` }}
+          />
+        ),
+        enableSorting: false,
+        enableColumnFilter: false,
+        meta: { align: 'center' },
+      },
+      columnHelper.accessor('nrodecomanda', {
+        id: 'nrodecomanda',
+        header: 'Nro. Comanda',
+        cell: (info) => info.getValue() ?? '—',
+        meta: { align: 'left' },
+      }),
+      columnHelper.display({
+        id: 'cliente',
+        header: 'Cliente',
+        cell: ({ row }) => row.original?.codcli?.razonsocial ?? '—',
+      }),
+      columnHelper.display({
+        id: 'producto',
+        header: 'Producto principal',
+        cell: ({ row }) => {
+          const descripcion = extractPrimaryProduct(row.original?.items);
+          return (
+            <Link
+              component="button"
+              onClick={() => setItemsModal({ open: true, comanda: row.original })}
+              underline="hover"
+              sx={{ fontWeight: 500 }}
+            >
+              {descripcion}
+            </Link>
+          );
+        },
+      }),
+      columnHelper.display({
+        id: 'fecha',
+        header: 'Fecha',
+        cell: ({ row }) => (row.original?.fecha ? dayjs(row.original.fecha).format('DD/MM/YYYY') : '—'),
+        meta: { align: 'center' },
+      }),
+      columnHelper.display({
+        id: 'cantidadEntregada',
+        header: 'Cant. entregada',
+        cell: ({ row }) => numberFormatter.format(sumDelivered(row.original?.items)),
+        meta: { align: 'right' },
+      }),
+      columnHelper.display({
+        id: 'lista',
+        header: 'Lista',
+        cell: ({ row }) => row.original?.items?.[0]?.lista?.lista ?? '—',
+      }),
+      columnHelper.display({
+        id: 'precioUnitario',
+        header: 'Precio unitario',
+        cell: ({ row }) => currencyFormatter.format(Number(row.original?.items?.[0]?.monto ?? 0)),
+        meta: { align: 'right' },
+      }),
+      columnHelper.display({
+        id: 'totalEntregado',
+        header: 'Total entregado',
+        cell: ({ row }) => currencyFormatter.format(sumDeliveredTotal(row.original?.items)),
+        meta: { align: 'right' },
+      }),
+      columnHelper.display({
+        id: 'estado',
+        header: 'Estado',
+        cell: ({ row }) => row.original?.codestado?.estado ?? '—',
+      }),
+      columnHelper.display({
+        id: 'ruta',
+        header: 'Ruta',
+        cell: ({ row }) => row.original?.codcli?.ruta?.ruta ?? row.original?.camion?.ruta ?? '—',
+      }),
+      columnHelper.display({
+        id: 'camionero',
+        header: 'Camionero',
+        cell: ({ row }) => {
+          const camionero = row.original?.camionero;
+          return camionero
+            ? `${camionero?.nombres ?? ''} ${camionero?.apellidos ?? ''}`.trim()
+            : '—';
+        },
+      }),
+      columnHelper.display({
+        id: 'puntoDistribucion',
+        header: 'Punto de distribución',
+        cell: ({ row }) => row.original?.puntoDistribucion ?? row.original?.camion?.camion ?? '—',
+      }),
+      columnHelper.display({
+        id: 'usuario',
+        header: 'Usuario',
+        cell: ({ row }) => {
+          const usuario = row.original?.usuario;
+          return usuario
+            ? `${usuario?.nombres ?? ''} ${usuario?.apellidos ?? ''}`.trim()
+            : '—';
+        },
+      }),
+      columnHelper.display({
+        id: 'acciones',
+        header: 'Acciones',
+        cell: ({ row }) => (
+          <Stack direction="row" spacing={1} justifyContent="center">
+            <Tooltip title="Gestionar logística">
+              <IconButton
+                color="primary"
+                onClick={() => setLogisticsDialog({ open: true, comandas: [row.original] })}
+              >
+                <LocalShippingIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Eliminar comanda">
+              <IconButton
+                color="error"
+                onClick={() => setDeleteDialog({ open: true, comandas: [row.original] })}
+              >
+                <DeleteOutlineIcon />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+        ),
+        enableSorting: false,
+        enableColumnFilter: false,
+        meta: { align: 'center' },
+      }),
+    ], []);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      columnFilters,
+      rowSelection,
+    },
+    onColumnFiltersChange: setColumnFilters,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    manualFiltering: true,
+    enableRowSelection: true,
+    getRowId: (row) => row?._id ?? String(row?.nrodecomanda ?? Math.random()),
+  });
+
+  const selectedComandas = table.getSelectedRowModel().flatRows.map((row) => row.original);
+
+  const showSnackbar = (message, severity = 'success') => {
+    setSnackbar({ open: true, message, severity });
+  };
+
+  const buildParamsFromFilters = useCallback(() => {
+    const params = { page, limit: PAGE_SIZE };
+    columnFilters.forEach(({ id, value }) => {
+      if (!value && value !== 0) return;
+      switch (id) {
+        case 'nrodecomanda':
+          if (value) params.nrocomanda = value;
+          break;
+        case 'cliente':
+          if (value?.id) params.cliente = value.id;
+          break;
+        case 'producto':
+          if (value?.id) params.producto = value.id;
+          break;
+        case 'fecha':
+          if (value?.desde) params.fechaDesde = value.desde;
+          if (value?.hasta) params.fechaHasta = value.hasta;
+          break;
+        case 'ruta':
+          if (value?.id) params.ruta = value.id;
+          break;
+        case 'camionero':
+          if (value?.id) params.camionero = value.id;
+          break;
+        case 'estado':
+          if (value?.id) params.estado = value.id;
+          break;
+        case 'usuario':
+          if (value?.id) params.usuario = value.id;
+          break;
+        case 'puntoDistribucion':
+          if (value) params.puntoDistribucion = value;
+          break;
+        default:
+          break;
+      }
+    });
+    return params;
+  }, [columnFilters, page]);
+
+  const fetchComandas = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = buildParamsFromFilters();
+      const { data: response } = await api.get('/comandas/logistica', { params });
+      setData(response.comandas ?? []);
+      setTotal(response.total ?? 0);
+      setTotalPages(response.totalPages ?? 0);
+      setRowSelection({});
+    } catch (error) {
+      console.error('Error obteniendo comandas activas', error);
+      showSnackbar('No se pudieron obtener las comandas activas', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [buildParamsFromFilters]);
+
+  useEffect(() => {
+    fetchComandas();
+  }, [fetchComandas]);
+
+  useEffect(() => {
+    const loadStaticData = async () => {
+      try {
+        const [estadosRes, rutasRes, camionesRes, camionerosRes, usuariosRes] = await Promise.all([
+          api.get('/estados'),
+          api.get('/rutas', { params: { limite: 200 } }),
+          api.get('/camiones', { params: { limite: 200 } }),
+          api.get('/usuarios/camioneros'),
+          api.get('/usuarios/lookup'),
+        ]);
+        setEstados(estadosRes.data.estados ?? []);
+        setRutas(rutasRes.data.rutas ?? []);
+        setCamiones(camionesRes.data.camiones ?? []);
+        setCamioneros(camionerosRes.data.usuarios ?? []);
+        setUsuarioOptions(
+          (usuariosRes.data.usuarios ?? [])
+            .map((usuario) => buildOption(usuario, (u) => `${u.nombres ?? ''} ${u.apellidos ?? ''}`.trim()))
+            .filter(Boolean),
+        );
+      } catch (error) {
+        console.error('Error cargando datos iniciales', error);
+        showSnackbar('No se pudieron cargar algunos datos auxiliares', 'warning');
+      }
+    };
+    loadStaticData();
+  }, []);
+
+  useEffect(() => () => {
+    if (clienteTimer.current) clearTimeout(clienteTimer.current);
+    if (clienteAbort.current) clienteAbort.current.abort();
+    if (productoTimer.current) clearTimeout(productoTimer.current);
+    if (productoAbort.current) productoAbort.current.abort();
+    if (camioneroTimer.current) clearTimeout(camioneroTimer.current);
+    if (usuarioTimer.current) clearTimeout(usuarioTimer.current);
+  }, []);
+
+  const handleClienteInput = useCallback((_, value) => {
+    if (clienteTimer.current) clearTimeout(clienteTimer.current);
+    if (clienteAbort.current) clienteAbort.current.abort();
+
+    if (!value || value.length < 3) {
+      setClienteOptions([]);
+      return;
+    }
+
+    if (clienteCache.current.has(value)) {
+      setClienteOptions(clienteCache.current.get(value));
+      return;
+    }
+
+    clienteTimer.current = setTimeout(async () => {
+      const controller = new AbortController();
+      clienteAbort.current = controller;
+      try {
+        const { data: response } = await api.get('/clientes/autocomplete', {
+          params: { term: value },
+          signal: controller.signal,
+        });
+        const options = (response.clientes ?? [])
+          .map((cliente) => buildOption(cliente, (c) => c.razonsocial ?? '—'))
+          .filter(Boolean);
+        clienteCache.current.set(value, options);
+        setClienteOptions(options);
+      } catch (error) {
+        if (error?.code !== 'ERR_CANCELED') {
+          console.error('Error buscando clientes', error);
+        }
+      }
+    }, 350);
+  }, []);
+
+  const handleProductoInput = useCallback((_, value) => {
+    if (productoTimer.current) clearTimeout(productoTimer.current);
+    if (productoAbort.current) productoAbort.current.abort();
+
+    if (!value || value.length < 3) {
+      setProductoOptions([]);
+      return;
+    }
+
+    if (productoCache.current.has(value)) {
+      setProductoOptions(productoCache.current.get(value));
+      return;
+    }
+
+    productoTimer.current = setTimeout(async () => {
+      const controller = new AbortController();
+      productoAbort.current = controller;
+      try {
+        const { data: response } = await api.get('/producservs/lookup', {
+          params: { q: value, limit: 20 },
+          signal: controller.signal,
+        });
+        const options = (response.producservs ?? [])
+          .map((prod) => buildOption(prod, (p) => p.descripcion ?? '—'))
+          .filter(Boolean);
+        productoCache.current.set(value, options);
+        setProductoOptions(options);
+      } catch (error) {
+        if (error?.code !== 'ERR_CANCELED') {
+          console.error('Error buscando productos', error);
+        }
+      }
+    }, 350);
+  }, []);
+
+  const handleCamioneroInput = useCallback((_, value) => {
+    if (camioneroTimer.current) clearTimeout(camioneroTimer.current);
+    camioneroTimer.current = setTimeout(async () => {
+      try {
+        const { data: response } = await api.get('/usuarios/camioneros', {
+          params: value && value.length >= 2 ? { term: value } : {},
+        });
+        setCamioneros(response.usuarios ?? []);
+      } catch (error) {
+        console.error('Error buscando camioneros', error);
+      }
+    }, 300);
+  }, []);
+
+  const handleUsuarioInput = useCallback((_, value) => {
+    if (usuarioTimer.current) clearTimeout(usuarioTimer.current);
+    usuarioTimer.current = setTimeout(async () => {
+      try {
+        const { data: response } = await api.get('/usuarios/lookup', {
+          params: value && value.length >= 2 ? { term: value } : {},
+        });
+        setUsuarioOptions(
+          (response.usuarios ?? [])
+            .map((usuario) => buildOption(usuario, (u) => `${u.nombres ?? ''} ${u.apellidos ?? ''}`.trim()))
+            .filter(Boolean),
+        );
+      } catch (error) {
+        console.error('Error buscando usuarios', error);
+      }
+    }, 300);
+  }, []);
+
+  const handleLogisticsSubmit = async ({ estado, camionero, camion, puntoDistribucion }) => {
+    if (!estado) {
+      showSnackbar('Seleccioná un estado logístico', 'warning');
+      return;
+    }
+    setSavingLogistics(true);
+    try {
+      const payload = {
+        codestado: estado,
+        puntoDistribucion: puntoDistribucion ?? '',
+      };
+      if (camionero) payload.camionero = camionero;
+      if (camion) payload.camion = camion;
+
+      await Promise.all(
+        (logisticsDialog.comandas ?? []).map((comanda) =>
+          api.put(`/comandas/${comanda._id}`, payload),
+        ),
+      );
+      showSnackbar('Actualización logística completada');
+      setLogisticsDialog({ open: false, comandas: [] });
+      fetchComandas();
+    } catch (error) {
+      console.error('Error actualizando logística', error);
+      showSnackbar('No se pudo actualizar la logística', 'error');
+    } finally {
+      setSavingLogistics(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    setDeleting(true);
+    try {
+      await Promise.all(
+        (deleteDialog.comandas ?? []).map((comanda) => api.delete(`/comandas/${comanda._id}`)),
+      );
+      showSnackbar('Comandas eliminadas correctamente');
+      setDeleteDialog({ open: false, comandas: [] });
+      fetchComandas();
+    } catch (error) {
+      console.error('Error eliminando comandas', error);
+      showSnackbar('No se pudieron eliminar las comandas', 'error');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleExportCsv = () => {
+    const headers = [
+      'Nro Comanda',
+      'Cliente',
+      'Producto principal',
+      'Fecha',
+      'Cantidad entregada',
+      'Lista',
+      'Precio unitario',
+      'Total entregado',
+      'Estado',
+      'Ruta',
+      'Camionero',
+      'Punto de distribución',
+      'Usuario',
+    ];
+
+    const rows = data.map((comanda) => [
+      comanda?.nrodecomanda ?? '',
+      comanda?.codcli?.razonsocial ?? '',
+      extractPrimaryProduct(comanda?.items),
+      comanda?.fecha ? dayjs(comanda.fecha).format('DD/MM/YYYY') : '',
+      numberFormatter.format(sumDelivered(comanda?.items)),
+      comanda?.items?.[0]?.lista?.lista ?? '',
+      currencyFormatter.format(Number(comanda?.items?.[0]?.monto ?? 0)),
+      currencyFormatter.format(sumDeliveredTotal(comanda?.items)),
+      comanda?.codestado?.estado ?? '',
+      comanda?.codcli?.ruta?.ruta ?? comanda?.camion?.ruta ?? '',
+      comanda?.camionero
+        ? `${comanda.camionero?.nombres ?? ''} ${comanda.camionero?.apellidos ?? ''}`.trim()
+        : '',
+      comanda?.puntoDistribucion ?? comanda?.camion?.camion ?? '',
+      comanda?.usuario
+        ? `${comanda.usuario?.nombres ?? ''} ${comanda.usuario?.apellidos ?? ''}`.trim()
+        : '',
+    ]);
+
+    const content = [headers, ...rows]
+      .map((row) =>
+        row
+          .map((value) => `"${String(value ?? '').replace(/"/g, '""')}"`)
+          .join(';'),
+      )
+      .join('\n');
+
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', `logistica_${dayjs().format('YYYYMMDD_HHmmss')}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPdf = () => {
+    const doc = new jsPDF({ orientation: 'landscape' });
+    doc.setFontSize(14);
+    doc.text('Comandas activas — Logística', 40, 30);
+    const head = [[
+      'Nro',
+      'Cliente',
+      'Producto',
+      'Fecha',
+      'Cant. entregada',
+      'Lista',
+      'Precio unitario',
+      'Total entregado',
+      'Estado',
+      'Ruta',
+      'Camionero',
+      'Punto de distribución',
+      'Usuario',
+    ]];
+    const body = data.map((comanda) => [
+      comanda?.nrodecomanda ?? '',
+      comanda?.codcli?.razonsocial ?? '',
+      extractPrimaryProduct(comanda?.items),
+      comanda?.fecha ? dayjs(comanda.fecha).format('DD/MM/YYYY') : '',
+      numberFormatter.format(sumDelivered(comanda?.items)),
+      comanda?.items?.[0]?.lista?.lista ?? '',
+      currencyFormatter.format(Number(comanda?.items?.[0]?.monto ?? 0)),
+      currencyFormatter.format(sumDeliveredTotal(comanda?.items)),
+      comanda?.codestado?.estado ?? '',
+      comanda?.codcli?.ruta?.ruta ?? comanda?.camion?.ruta ?? '',
+      comanda?.camionero
+        ? `${comanda.camionero?.nombres ?? ''} ${comanda.camionero?.apellidos ?? ''}`.trim()
+        : '',
+      comanda?.puntoDistribucion ?? comanda?.camion?.camion ?? '',
+      comanda?.usuario
+        ? `${comanda.usuario?.nombres ?? ''} ${comanda.usuario?.apellidos ?? ''}`.trim()
+        : '',
+    ]);
+    autoTable(doc, {
+      startY: 50,
+      head,
+      body,
+      styles: { fontSize: 9 },
+      headStyles: { fillColor: [41, 128, 185] },
+      alternateRowStyles: { fillColor: [243, 246, 249] },
+    });
+    doc.save(`logistica_${dayjs().format('YYYYMMDD_HHmmss')}.pdf`);
+  };
+
+  const handleClearFilters = () => {
+    table.resetColumnFilters();
+    setColumnFilters([]);
+    setPage(1);
+  };
+
+  const handleReload = () => {
+    fetchComandas();
+  };
+
+  const clienteColumn = table.getColumn('cliente');
+  const productoColumn = table.getColumn('producto');
+  const fechaColumn = table.getColumn('fecha');
+  const rutaColumn = table.getColumn('ruta');
+  const camioneroColumn = table.getColumn('camionero');
+  const estadoColumn = table.getColumn('estado');
+  const usuarioColumn = table.getColumn('usuario');
+  const puntoDistribucionColumn = table.getColumn('puntoDistribucion');
+  const nroColumn = table.getColumn('nrodecomanda');
+
+  const clienteValue = safeGetFilterValue(clienteColumn);
+  const productoValue = safeGetFilterValue(productoColumn);
+  const rutaValue = safeGetFilterValue(rutaColumn);
+  const camioneroValue = safeGetFilterValue(camioneroColumn);
+  const estadoValue = safeGetFilterValue(estadoColumn);
+  const usuarioValue = safeGetFilterValue(usuarioColumn);
+  const fechaValue = safeGetFilterValue(fechaColumn) || { desde: '', hasta: '' };
+  const puntoDistribucionValue = safeGetFilterValue(puntoDistribucionColumn) ?? '';
+  const nroValue = safeGetFilterValue(nroColumn) ?? '';
+
+  const estadoOptions = useMemo(
+    () => estados.map((estado) => buildOption(estado, (e) => e.estado ?? '—')).filter(Boolean),
+    [estados],
+  );
+  const rutaOptions = useMemo(
+    () => rutas.map((ruta) => buildOption(ruta, (r) => r.ruta ?? '—')).filter(Boolean),
+    [rutas],
+  );
+  const camioneroOptions = useMemo(
+    () => camioneros.map((camionero) => buildOption(camionero, (u) => `${u.nombres ?? ''} ${u.apellidos ?? ''}`.trim())).filter(Boolean),
+    [camioneros],
+  );
+  const camionOptions = useMemo(
+    () => camiones.map((camion) => buildOption(camion, (c) => c.camion ?? '—')).filter(Boolean),
+    [camiones],
+  );
+  const puntoDistribucionOption = puntoDistribucionValue
+    ? { id: puntoDistribucionValue, label: puntoDistribucionValue }
+    : null;
+  const puntoDistribucionOptions = useMemo(
+    () => camionOptions.map((option) => ({ id: option.label, label: option.label })),
+    [camionOptions],
+  );
+
+  const handlePageChange = (_, value) => {
+    setPage(value);
+  };
+
+  useEffect(() => {
+    setPage(1);
+  }, [columnFilters]);
+
+  const ensureOptionPresence = useCallback((optionsList, value) => {
+    if (!value) return optionsList;
+    const exists = optionsList.some((opt) => opt?.id === value?.id);
+    return exists ? optionsList : [value, ...optionsList];
+  }, []);
+
+  const handleDateChange = (key, newValue) => {
+    const current = fechaColumn?.getFilterValue?.() || {};
+    const next = { ...current, [key]: newValue || undefined };
+    if (!next.desde && !next.hasta) {
+      fechaColumn?.setFilterValue(undefined);
+    } else {
+      fechaColumn?.setFilterValue(next);
+    }
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3, flexWrap: 'wrap', gap: 2 }}>
+        <Typography variant="h4">Logística</Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap">
+          <Button variant="outlined" startIcon={<FileDownloadIcon />} onClick={handleExportCsv}>
+            Exportar CSV
+          </Button>
+          <Button variant="outlined" startIcon={<PictureAsPdfIcon />} onClick={handleExportPdf}>
+            Exportar PDF
+          </Button>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={handleReload}>
+            Recargar
+          </Button>
+          <Button variant="outlined" startIcon={<CleaningServicesIcon />} onClick={handleClearFilters}>
+            Limpiar filtros
+          </Button>
+        </Stack>
+      </Stack>
+
+      <Paper sx={{ p: 2, mb: 3 }}>
+        <Grid container spacing={2}>
+          <Grid item xs={12} sm={6} md={3}>
+            <TextField
+              label="Nro. de comanda"
+              value={nroValue}
+              onChange={(event) => nroColumn?.setFilterValue(event.target.value || undefined)}
+              fullWidth
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={clienteValue}
+              options={ensureOptionPresence(clienteOptions, clienteValue)}
+              onChange={(_, value) => clienteColumn?.setFilterValue(value ?? undefined)}
+              onInputChange={handleClienteInput}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              renderInput={(params) => <TextField {...params} label="Cliente" placeholder="Buscar cliente" />}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={productoValue}
+              options={ensureOptionPresence(productoOptions, productoValue)}
+              onChange={(_, value) => productoColumn?.setFilterValue(value ?? undefined)}
+              onInputChange={handleProductoInput}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              renderInput={(params) => <TextField {...params} label="Producto" placeholder="Buscar producto" />}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <TextField
+              type="date"
+              label="Fecha desde"
+              InputLabelProps={{ shrink: true }}
+              value={fechaValue?.desde ?? ''}
+              onChange={(event) => handleDateChange('desde', event.target.value)}
+              fullWidth
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <TextField
+              type="date"
+              label="Fecha hasta"
+              InputLabelProps={{ shrink: true }}
+              value={fechaValue?.hasta ?? ''}
+              onChange={(event) => handleDateChange('hasta', event.target.value)}
+              fullWidth
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={rutaValue}
+              options={ensureOptionPresence(rutaOptions, rutaValue)}
+              onChange={(_, value) => rutaColumn?.setFilterValue(value ?? undefined)}
+              renderInput={(params) => <TextField {...params} label="Ruta" placeholder="Seleccionar ruta" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={camioneroValue}
+              options={ensureOptionPresence(camioneroOptions, camioneroValue)}
+              onChange={(_, value) => camioneroColumn?.setFilterValue(value ?? undefined)}
+              onInputChange={handleCamioneroInput}
+              renderInput={(params) => <TextField {...params} label="Camionero" placeholder="Buscar" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={estadoValue}
+              options={ensureOptionPresence(estadoOptions, estadoValue)}
+              onChange={(_, value) => estadoColumn?.setFilterValue(value ?? undefined)}
+              renderInput={(params) => <TextField {...params} label="Estado" placeholder="Seleccionar estado" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={usuarioValue}
+              options={ensureOptionPresence(usuarioOptions, usuarioValue)}
+              onChange={(_, value) => usuarioColumn?.setFilterValue(value ?? undefined)}
+              onInputChange={handleUsuarioInput}
+              renderInput={(params) => <TextField {...params} label="Usuario" placeholder="Buscar usuario" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Autocomplete
+              value={puntoDistribucionOption}
+              options={ensureOptionPresence(puntoDistribucionOptions, puntoDistribucionOption)}
+              freeSolo
+              onChange={(_, value) =>
+                puntoDistribucionColumn?.setFilterValue(typeof value === 'string' ? value : value?.label ?? undefined)
+              }
+              onInputChange={(_, value) => puntoDistribucionColumn?.setFilterValue(value || undefined)}
+              renderInput={(params) => <TextField {...params} label="Punto de distribución" placeholder="Depósito" />}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+            />
+          </Grid>
+        </Grid>
+      </Paper>
+
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
+
+      {selectedComandas.length > 0 && (
+        <Paper sx={{ p: 2, mb: 2, bgcolor: 'background.default', border: '1px solid', borderColor: 'divider' }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center" justifyContent="space-between">
+            <Typography variant="subtitle1">
+              {selectedComandas.length} comandas seleccionadas
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <Button
+                startIcon={<LocalShippingIcon />}
+                variant="contained"
+                color="primary"
+                onClick={() => setLogisticsDialog({ open: true, comandas: selectedComandas })}
+              >
+                Asignar logística
+              </Button>
+              <Button
+                startIcon={<DeleteOutlineIcon />}
+                variant="outlined"
+                color="error"
+                onClick={() => setDeleteDialog({ open: true, comandas: selectedComandas })}
+              >
+                Eliminar seleccionadas
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      )}
+
+      <Paper sx={{ overflow: 'hidden' }}>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableCell
+                      key={header.id}
+                      align={header.column.columnDef.meta?.align ?? 'left'}
+                      sx={{ fontWeight: 600, bgcolor: 'grey.100' }}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHead>
+            <TableBody>
+              {data.length === 0 && !loading ? (
+                <TableRow>
+                  <TableCell colSpan={table.getAllColumns().length} align="center">
+                    <Typography variant="body2" color="text.secondary">
+                      No se encontraron comandas activas con los filtros seleccionados.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                table.getRowModel().rows.map((row, index) => (
+                  <TableRow
+                    key={row.id}
+                    hover
+                    sx={{ bgcolor: index % 2 === 0 ? 'background.paper' : 'grey.50' }}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id} align={cell.column.columnDef.meta?.align ?? 'left'}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <Divider />
+        <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+          <Typography variant="body2" color="text.secondary">
+            Página {page} de {totalPages} — {total} resultados
+          </Typography>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={page <= 1}
+              onClick={() => handlePageChange(null, page - 1)}
+            >
+              Anterior
+            </Button>
+            <Typography variant="body2">{page}</Typography>
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={page >= totalPages}
+              onClick={() => handlePageChange(null, page + 1)}
+            >
+              Siguiente
+            </Button>
+          </Stack>
+        </Box>
+      </Paper>
+
+      <ItemsModal
+        open={itemsModal.open}
+        comanda={itemsModal.comanda}
+        onClose={() => setItemsModal({ open: false, comanda: null })}
+      />
+
+      <LogisticsActionDialog
+        open={logisticsDialog.open}
+        comandas={logisticsDialog.comandas}
+        onClose={() => setLogisticsDialog({ open: false, comandas: [] })}
+        onSubmit={handleLogisticsSubmit}
+        estados={estados}
+        camioneros={camioneros}
+        camiones={camiones}
+        loading={savingLogistics}
+      />
+
+      <DeleteConfirmationDialog
+        open={deleteDialog.open}
+        comandas={deleteDialog.comandas}
+        onClose={() => setDeleteDialog({ open: false, comandas: [] })}
+        onConfirm={handleDeleteConfirm}
+        loading={deleting}
+      />
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
 }


### PR DESCRIPTION
## Summary
- add `puntoDistribucion` field and logistics listing endpoint with safe filtering and paging
- expose camionero and generic user lookups for logistics assignments
- build the /logistics React page with TanStack Table, async filters, exports, and mass actions
- create reusable logistics modals for item detail, status assignment, and deletions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57259e9c08321aa346c21bd628e01