### PR TITLE
feat(logistics): color code status column

### DIFF
--- a/frontend/src/constants/logisticsStatusColors.js
+++ b/frontend/src/constants/logisticsStatusColors.js
@@ -1,0 +1,48 @@
+const COLOR_BLUE = '#1E88E5';
+const COLOR_YELLOW = '#FFC107';
+const COLOR_GREEN = '#2E7D32';
+const COLOR_ORANGE = '#FB8C00';
+const COLOR_RED = '#D32F2F';
+
+const normalizeStatus = (estado) =>
+  (estado ?? '')
+    .toString()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .trim()
+    .toLowerCase();
+
+const STATUS_COLOR_RULES = [
+  { matchers: ['entregado', 'finalizado', 'completado'], color: COLOR_GREEN },
+  { matchers: ['pendiente', 'solicitado', 'nuevo'], color: COLOR_YELLOW },
+  { matchers: ['demorado', 'demora', 'reprogramado', 'postergado'], color: COLOR_ORANGE },
+  {
+    matchers: ['cancelado', 'rechazado', 'anulado', 'devuelto', 'no entregado'],
+    color: COLOR_RED,
+  },
+  {
+    matchers: ['transito', 'tránsito', 'camino', 'enviado', 'curso', 'asignado'],
+    color: COLOR_BLUE,
+  },
+];
+
+export const LOGISTICS_STATUS_COLORS = {
+  blue: COLOR_BLUE,
+  yellow: COLOR_YELLOW,
+  green: COLOR_GREEN,
+  orange: COLOR_ORANGE,
+  red: COLOR_RED,
+};
+
+export const getLogisticsStatusColor = (estado) => {
+  const normalized = normalizeStatus(estado);
+  if (!normalized) {
+    return COLOR_BLUE;
+  }
+
+  const matchedRule = STATUS_COLOR_RULES.find((rule) =>
+    rule.matchers.some((matcher) => normalized.includes(matcher)),
+  );
+
+  return matchedRule?.color ?? COLOR_BLUE;
+};

--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -37,6 +37,7 @@ import api from '../api/axios';
 import ItemsModal from '../components/logistics/ItemsModal.jsx';
 import LogisticsActionDialog from '../components/logistics/LogisticsActionDialog.jsx';
 import DeleteConfirmationDialog from '../components/logistics/DeleteConfirmationDialog.jsx';
+import { getLogisticsStatusColor } from '../constants/logisticsStatusColors.js';
 
 const PAGE_SIZE = 20;
 const columnHelper = createColumnHelper();
@@ -221,7 +222,16 @@ export default function LogisticsPage() {
       columnHelper.display({
         id: 'estado',
         header: 'Estado',
-        cell: ({ row }) => row.original?.codestado?.estado ?? '—',
+        cell: ({ row }) => {
+          const estado = row.original?.codestado?.estado ?? '—';
+          const color = getLogisticsStatusColor(row.original?.codestado?.estado);
+
+          return (
+            <Typography component="span" sx={{ color, fontWeight: 600 }}>
+              {estado}
+            </Typography>
+          );
+        },
         enableSorting: true,
         sortingFn: (rowA, rowB) =>
           collator.compare(rowA.original?.codestado?.estado ?? '', rowB.original?.codestado?.estado ?? ''),


### PR DESCRIPTION
## Summary
- wrap the logistics estado column value in a Typography component with dynamic color coding
- centralize reusable logistics status color mapping helpers for future components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70199093c83219a2c2273801d8865