### PR TITLE
Map logistics sorting columns to backend fields

### DIFF
--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -357,16 +357,26 @@ export default function LogisticsPage() {
     const params = { page, limit: PAGE_SIZE };
     const sortingColumnMap = {
       nrodecomanda: 'nrodecomanda',
+      cliente: 'codcli.razonsocial',
+      producto: 'productoPrincipal.descripcion',
       fecha: 'fecha',
-      estado: 'codestado',
+      cantidadEntregada: 'totales.cantidadEntregada',
+      precioTotal: 'totales.precioSolicitado',
+      totalEntregado: 'totales.totalEntregado',
+      estado: 'codestado.estado',
+      ruta: 'codcli.ruta.ruta',
+      camionero: 'camioneroNombre',
       puntoDistribucion: 'puntoDistribucion',
+      usuario: 'usuarioNombre',
     };
     const [currentSorting] = sorting;
     if (currentSorting) {
       const sortField = sortingColumnMap[currentSorting.id];
-      if (sortField) {
+      const sortOrder =
+        currentSorting.desc === true ? 'desc' : currentSorting.desc === false ? 'asc' : null;
+      if (sortField && sortOrder) {
         params.sortField = sortField;
-        params.sortOrder = currentSorting.desc ? 'desc' : 'asc';
+        params.sortOrder = sortOrder;
       }
     }
     columnFilters.forEach(({ id, value }) => {


### PR DESCRIPTION
## Summary
- map each sortable logistics column to the backend sort field, including clients, products, totals, status, routing, and users
- only append sort parameters when both field and order are valid while preserving the existing page reset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71701d0c88321bf437cbd1b541516