### PR TITLE
Enable client-side sorting on logistics table

### DIFF
--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -30,7 +30,13 @@ import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import dayjs from 'dayjs';
-import { createColumnHelper, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import api from '../api/axios';
@@ -342,7 +348,7 @@ export default function LogisticsPage() {
     onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     manualFiltering: true,
-    manualSorting: true,
+    getSortedRowModel: getSortedRowModel(),
     enableRowSelection: true,
     getRowId: (row) => row?._id ?? String(row?.nrodecomanda ?? Math.random()),
   });


### PR DESCRIPTION
## Summary
- import the TanStack sorted row model helper and enable it in the logistics table
- remove the manual sorting flag so the table can compute its own sorted rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d736a714a8832184dcbc504e911caa