### PR TITLE
Disable sorting on logistics product column

### DIFF
--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -181,12 +181,7 @@ export default function LogisticsPage() {
               </Link>
             );
           },
-          enableSorting: true,
-          sortingFn: (rowA, rowB) =>
-            collator.compare(
-              extractPrimaryProduct(rowA.original?.items),
-              extractPrimaryProduct(rowB.original?.items),
-            ),
+          enableSorting: false,
         },
       ),
       columnHelper.accessor(


### PR DESCRIPTION
## Summary
- disable sorting for the logistics product column by turning off sorting and removing its custom comparator
- keep backend sorting parameters unchanged by leaving the sorting column map untouched

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d94d607ca08321bdadb92130a8695e