### PR TITLE
Adjust customer autocomplete width

### DIFF
--- a/frontend/src/pages/ComandasPage.jsx
+++ b/frontend/src/pages/ComandasPage.jsx
@@ -340,7 +340,11 @@ export default function ComandasPage() {
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Comandas</Typography>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ flexWrap: 'wrap' }}
+      >
         <TextField
           label="Buscar"
           value={busqueda}
@@ -374,7 +378,7 @@ export default function ComandasPage() {
           loading={clienteLoading}
           noOptionsText={clienteNoOpts}
           renderInput={(params) => <TextField {...params} label="Cliente" />}
-          sx={{ minWidth: 240 }}
+          sx={{ width: { xs: '100%', sm: 480 } }}
         />
       </Stack>
 


### PR DESCRIPTION
## Summary
- widen the customer autocomplete to improve readability on larger screens
- allow the filter stack to wrap so the wider field keeps the layout responsive

## Testing
- Visual check using Vite dev server

------
https://chatgpt.com/codex/tasks/task_e_68da6ebfbe848321b3dde4c80119c0ab