### PR TITLE
Add logistics status counters to page header

### DIFF
--- a/frontend/src/pages/LogisticsPage.jsx
+++ b/frontend/src/pages/LogisticsPage.jsx
@@ -41,6 +41,14 @@ import DeleteConfirmationDialog from '../components/logistics/DeleteConfirmation
 const PAGE_SIZE = 20;
 const columnHelper = createColumnHelper();
 
+const STATUS_CONFIG = [
+  { key: 'A preparar', label: 'A preparar', color: '#1976d2' },
+  { key: 'Preparada', label: 'Preparada', color: '#9c27b0' },
+  { key: 'En distribución', label: 'En distribución', color: '#fdd835' },
+  { key: 'Entrega parcial', label: 'Entrega parcial', color: '#fb8c00' },
+  { key: 'Cerrada', label: 'Cerrada', color: '#2e7d32' },
+];
+
 const numberFormatter = new Intl.NumberFormat('es-AR', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
@@ -122,6 +130,22 @@ export default function LogisticsPage() {
   const usuarioTimer = useRef(null);
 
   const collator = useMemo(() => new Intl.Collator('es', { sensitivity: 'base', numeric: true }), []);
+
+  const statusCounts = useMemo(() => {
+    const counts = {};
+    STATUS_CONFIG.forEach(({ key }) => {
+      counts[key] = 0;
+    });
+
+    (data ?? []).forEach((comanda) => {
+      const estado = comanda?.codestado?.estado;
+      if (estado && Object.prototype.hasOwnProperty.call(counts, estado)) {
+        counts[estado] += 1;
+      }
+    });
+
+    return counts;
+  }, [data]);
 
   const columns = useMemo(() => [
       {
@@ -804,7 +828,27 @@ export default function LogisticsPage() {
   return (
     <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3, flexWrap: 'wrap', gap: 2 }}>
-        <Typography variant="h4">Logística</Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Typography variant="h4">Logística</Typography>
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            {STATUS_CONFIG.map((status) => (
+              <Stack key={status.key} direction="row" spacing={1} alignItems="center">
+                <Box
+                  sx={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: '50%',
+                    bgcolor: status.color,
+                    boxShadow: `0 0 0 2px rgba(0, 0, 0, 0.08)`,
+                  }}
+                />
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {`${status.label}: ${statusCounts[status.key] ?? 0}`}
+                </Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
         <Stack direction="row" spacing={1} flexWrap="wrap">
           <Button variant="outlined" startIcon={<FileDownloadIcon />} onClick={handleExportCsv}>
             Exportar CSV


### PR DESCRIPTION
## Summary
- derive required logistics state counts from fetched comandas
- render colored status indicators alongside the Logística page title
- keep the counters in sync with backend updates through memoized calculations

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: build error due to missing jspdf dependency in existing project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68da845599888321bbacafcbdcb5e8c9