### PR TITLE
feat(frontend): add orders page route

### DIFF
--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -5,6 +5,7 @@ import ProductsPage from './pages/ProductsPage.jsx';
 import ComandasPage from './pages/ComandasPage.jsx';
 import DocumentsPage from './pages/DocumentsPage.jsx';
 import LogisticsPage from './pages/LogisticsPage.jsx';
+import OrdersPage from './pages/OrdersPage.jsx';
 import LoginForm from './pages/LoginForm';
 import PrivateRoute from './components/PrivateRoute';
 import HistorialComandas from './components/HistorialComandas.jsx';
@@ -25,6 +26,7 @@ export default function AppRoutes({ themeName, setThemeName }) {
         <Route path="/products" element={<ProductsPage />} />
         <Route path="/documents" element={<DocumentsPage />} />
         <Route path="comandas" element={<ComandasPage />} />
+        <Route path="/ordenes" element={<OrdersPage />} />
         <Route path="/historial-comandas" element={<HistorialComandas />} />
         <Route path="/logistics" element={<LogisticsPage />} />
         {/* Otras rutas aquí */}

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -28,6 +28,7 @@ import Inventory2Icon from '@mui/icons-material/Inventory2';
 import SecurityIcon from '@mui/icons-material/Security';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import ListAltIcon from '@mui/icons-material/ListAlt';
 import HistoryIcon from '@mui/icons-material/History';
 import DescriptionIcon from '@mui/icons-material/Description';
 import ThemeSelector from '../components/ThemeSelector.jsx';
@@ -41,6 +42,7 @@ const navItems = [
   { label: 'Productos', path: '/products',     icon: <Inventory2Icon /> }, // 👈 NUEVO
   { label: 'Documentos', path: '/documents', icon: <DescriptionIcon /> },
   { label: 'Comandas', path: '/comandas', icon: <ReceiptLongIcon /> },
+  { label: 'Órdenes', path: '/ordenes', icon: <ListAltIcon /> },
   { label: 'Historial', path: '/historial-comandas', icon: <HistoryIcon /> },
   { label: 'Permisos', path: '/permissions', icon: <SecurityIcon /> },
   { label: 'Logística', path: '/logistics',  icon: <LocalShippingIcon /> },

--- a/frontend/src/pages/OrdersPage.jsx
+++ b/frontend/src/pages/OrdersPage.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Stack, Typography } from '@mui/material';
+
+export default function OrdersPage() {
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Órdenes</Typography>
+      <Typography variant="body1">
+        Gestiona y revisa el estado de las órdenes desde este módulo.
+      </Typography>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add a placeholder orders page component
- register the orders route and expose it from the dashboard navigation

## Testing
- npm run lint *(fails: LogisticsPage.jsx has an existing unused variable)*

------
https://chatgpt.com/codex/tasks/task_e_68daabcf1bcc8321ad1b2cb6c9624dbb