### PR TITLE
Avoid redundant merges when options unchanged

### DIFF
--- a/frontend/src/pages/OrdersPage.jsx
+++ b/frontend/src/pages/OrdersPage.jsx
@@ -50,7 +50,7 @@ const buildOption = (id, label, raw = null) => {
 
 const mergeOptions = (prev = [], next = []) => {
   const map = new Map();
-  [...prev, ...next].forEach((option) => {
+  prev.forEach((option) => {
     if (!option) return;
     const key = option.id ?? option.label;
     if (!key) return;
@@ -58,6 +58,20 @@ const mergeOptions = (prev = [], next = []) => {
       map.set(key, option);
     }
   });
+
+  const initialSize = map.size;
+
+  next.forEach((option) => {
+    if (!option) return;
+    const key = option.id ?? option.label;
+    if (!key || map.has(key)) return;
+    map.set(key, option);
+  });
+
+  if (map.size === initialSize) {
+    return prev;
+  }
+
   return Array.from(map.values());
 };
 


### PR DESCRIPTION
## Summary
- update `mergeOptions` to preserve the previous options array when no new option ids or labels are added
- prevent unnecessary state updates in the orders page option refresh logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0771e019c8321a20ee6885226cab0